### PR TITLE
Add option to compress log files after dumping

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -45,6 +45,7 @@
 - Implement internal log queue
 - It's a secret...
 - Updated to DIC version 20210401
+- Support log file compression
 
 ### 1.18 (2020-11-10)
 - Add more information extraction and generation for Aaru

--- a/MPF.Check/Program.cs
+++ b/MPF.Check/Program.cs
@@ -65,7 +65,7 @@ namespace MPF.Check
             string username = null, password = null;
             string internalProgram = "DiscImageCreator";
             string path = string.Empty;
-            bool scan = false;
+            bool scan = false, compress = false;
 
             // Loop through and process options
             int startIndex = 2;
@@ -111,6 +111,12 @@ namespace MPF.Check
                 else if (args[startIndex].StartsWith("-s") || args[startIndex].StartsWith("--scan"))
                 {
                     scan = true;
+                }
+
+                // Compress log and extraneous files
+                else if (args[startIndex].StartsWith("-z") || args[startIndex].StartsWith("--zip"))
+                {
+                    compress = true;
                 }
 
                 // Default, we fall out
@@ -160,6 +166,7 @@ namespace MPF.Check
                     InternalProgram = Converters.ToInternalProgram(internalProgram),
                     ScanForProtection = scan && !string.IsNullOrWhiteSpace(path),
                     PromptForDiscInformation = false,
+                    CompressLogFiles = compress,
 
                     RedumpUsername = username,
                     RedumpPassword = password,
@@ -200,6 +207,7 @@ namespace MPF.Check
             Console.WriteLine("-u, --use <program>            Dumping program output type");
             Console.WriteLine("-p, --path <drivepath>         Physical drive path for additional checks");
             Console.WriteLine("-s, --scan                     Enable copy protection scan (requires --path)");
+            Console.WriteLine("-z, --zip                      Enable log file compression");
             Console.WriteLine();
         }
 

--- a/MPF.Library/Aaru/Parameters.cs
+++ b/MPF.Library/Aaru/Parameters.cs
@@ -1034,6 +1034,48 @@ namespace MPF.Aaru
         public override string GetDefaultExtension(MediaType? mediaType) => Converters.Extension(mediaType);
 
         /// <inheritdoc/>
+        public override List<string> GetLogFilePaths(string basePath)
+        {
+            List<string> logFiles = new List<string>();
+            switch (this.Type)
+            {
+                case MediaType.CDROM:
+                    if (File.Exists($"{basePath}.cicm.xml"))
+                        logFiles.Add($"{basePath}.cicm.xml");
+                    if (File.Exists($"{basePath}.ibg"))
+                        logFiles.Add($"{basePath}.ibg");
+                    if (File.Exists($"{basePath}.log"))
+                        logFiles.Add($"{basePath}.log");
+                    if (File.Exists($"{basePath}.mhddlog.bin"))
+                        logFiles.Add($"{basePath}.mhddlog.bin");
+                    if (File.Exists($"{basePath}.resume.xml"))
+                        logFiles.Add($"{basePath}.resume.xml");
+                    if (File.Exists($"{basePath}.sub.log"))
+                        logFiles.Add($"{basePath}.sub.log");
+
+                    break;
+
+                case MediaType.DVD:
+                case MediaType.HDDVD:
+                case MediaType.BluRay:
+                    if (File.Exists($"{basePath}.cicm.xml"))
+                        logFiles.Add($"{basePath}.cicm.xml");
+                    if (File.Exists($"{basePath}.ibg"))
+                        logFiles.Add($"{basePath}.ibg");
+                    if (File.Exists($"{basePath}.log"))
+                        logFiles.Add($"{basePath}.log");
+                    if (File.Exists($"{basePath}.mhddlog.bin"))
+                        logFiles.Add($"{basePath}.mhddlog.bin");
+                    if (File.Exists($"{basePath}.resume.xml"))
+                        logFiles.Add($"{basePath}.resume.xml");
+
+                    break;
+            }
+
+            return logFiles;
+        }
+
+        /// <inheritdoc/>
         public override bool IsDumpingCommand()
         {
             switch (BaseCommand)

--- a/MPF.Library/Aaru/Parameters.cs
+++ b/MPF.Library/Aaru/Parameters.cs
@@ -205,7 +205,7 @@ namespace MPF.Aaru
         }
 
         /// <inheritdoc/>
-        public override void GenerateSubmissionInfo(SubmissionInfo info, string basePath, Drive drive)
+        public override void GenerateSubmissionInfo(SubmissionInfo info, string basePath, Drive drive, bool includeArtifacts)
         {
             // TODO: Fill in submission info specifics for Aaru
             string outputDirectory = Path.GetDirectoryName(basePath);
@@ -365,19 +365,22 @@ namespace MPF.Aaru
                     break;
             }
 
-            // Fill in any artifacts that exist, Base64-encoded
-            if (File.Exists(basePath + ".cicm.xml"))
-                info.Artifacts["cicm"] = GetBase64(GetFullFile(basePath + ".cicm.xml"));
-            if (File.Exists(basePath + ".ibg"))
-                info.Artifacts["ibg"] = Convert.ToBase64String(File.ReadAllBytes(basePath + ".ibg"));
-            if (File.Exists(basePath + ".log"))
-                info.Artifacts["log"] = GetBase64(GetFullFile(basePath + ".log"));
-            if (File.Exists(basePath + ".mhddlog.bin"))
-                info.Artifacts["mhddlog_bin"] = Convert.ToBase64String(File.ReadAllBytes(basePath + ".mhddlog.bin"));
-            if (File.Exists(basePath + ".resume.xml"))
-                info.Artifacts["resume"] = GetBase64(GetFullFile(basePath + ".resume.xml"));
-            if (File.Exists(basePath + ".sub.log"))
-                info.Artifacts["sub_log"] = GetBase64(GetFullFile(basePath + ".sub.log"));
+            // Fill in any artifacts that exist, Base64-encoded, if we need to
+            if (includeArtifacts)
+            {
+                if (File.Exists(basePath + ".cicm.xml"))
+                    info.Artifacts["cicm"] = GetBase64(GetFullFile(basePath + ".cicm.xml"));
+                if (File.Exists(basePath + ".ibg"))
+                    info.Artifacts["ibg"] = Convert.ToBase64String(File.ReadAllBytes(basePath + ".ibg"));
+                if (File.Exists(basePath + ".log"))
+                    info.Artifacts["log"] = GetBase64(GetFullFile(basePath + ".log"));
+                if (File.Exists(basePath + ".mhddlog.bin"))
+                    info.Artifacts["mhddlog_bin"] = Convert.ToBase64String(File.ReadAllBytes(basePath + ".mhddlog.bin"));
+                if (File.Exists(basePath + ".resume.xml"))
+                    info.Artifacts["resume"] = GetBase64(GetFullFile(basePath + ".resume.xml"));
+                if (File.Exists(basePath + ".sub.log"))
+                    info.Artifacts["sub_log"] = GetBase64(GetFullFile(basePath + ".sub.log"));
+            }
         }
 
         /// <inheritdoc/>

--- a/MPF.Library/CleanRIp/Parameters.cs
+++ b/MPF.Library/CleanRIp/Parameters.cs
@@ -99,6 +99,26 @@ namespace MPF.CleanRip
             }
         }
 
+        /// <inheritdoc/>
+        public override List<string> GetLogFilePaths(string basePath)
+        {
+            List<string> logFiles = new List<string>();
+            switch (this.Type)
+            {
+                case MediaType.DVD: // Only added here to help users; not strictly correct
+                case MediaType.NintendoGameCubeGameDisc:
+                case MediaType.NintendoWiiOpticalDisc:
+                    if (File.Exists($"{basePath}-dumpinfo.txt"))
+                        logFiles.Add($"{basePath}-dumpinfo.txt");
+                    if (File.Exists($"{basePath}.bca"))
+                        logFiles.Add($"{basePath}.bca");
+
+                    break;
+            }
+
+            return logFiles;
+        }
+
         #endregion
 
         #region Information Extraction Methods

--- a/MPF.Library/CleanRIp/Parameters.cs
+++ b/MPF.Library/CleanRIp/Parameters.cs
@@ -54,7 +54,7 @@ namespace MPF.CleanRip
         }
 
         /// <inheritdoc/>
-        public override void GenerateSubmissionInfo(SubmissionInfo info, string basePath, Drive drive)
+        public override void GenerateSubmissionInfo(SubmissionInfo info, string basePath, Drive drive, bool includeArtifacts)
         {
             info.TracksAndWriteOffsets.ClrMameProData = GetCleanripDatfile(basePath + ".iso", basePath + "-dumpinfo.txt");
             
@@ -89,11 +89,14 @@ namespace MPF.CleanRip
                     break;
             }
 
-            // Fill in any artifacts that exist, Base64-encoded
-            if (File.Exists(basePath + ".bca"))
-                info.Artifacts["bca"] = GetBase64(GetFullFile(basePath + ".bca", binary: true));
-            if (File.Exists(basePath + "-dumpinfo.txt"))
-                info.Artifacts["dumpinfo"] = GetBase64(GetFullFile(basePath + "-dumpinfo.txt"));
+            // Fill in any artifacts that exist, Base64-encoded, if we need to
+            if (includeArtifacts)
+            {
+                if (File.Exists(basePath + ".bca"))
+                    info.Artifacts["bca"] = GetBase64(GetFullFile(basePath + ".bca", binary: true));
+                if (File.Exists(basePath + "-dumpinfo.txt"))
+                    info.Artifacts["dumpinfo"] = GetBase64(GetFullFile(basePath + "-dumpinfo.txt"));
+            }
         }
 
         #endregion

--- a/MPF.Library/DD/Parameters.cs
+++ b/MPF.Library/DD/Parameters.cs
@@ -101,7 +101,7 @@ namespace MPF.DD
         }
 
         /// <inheritdoc/>
-        public override void GenerateSubmissionInfo(SubmissionInfo info, string basePath, Drive drive)
+        public override void GenerateSubmissionInfo(SubmissionInfo info, string basePath, Drive drive, bool includeArtifacts)
         {
             // TODO: Fill in submission info specifics for DD
             string outputDirectory = Path.GetDirectoryName(basePath);

--- a/MPF.Library/Data/BaseParameters.cs
+++ b/MPF.Library/Data/BaseParameters.cs
@@ -123,7 +123,8 @@ namespace MPF.Data
         /// <param name="submissionInfo">Base submission info to fill in specifics for</param>
         /// <param name="basePath">Base filename and path to use for checking</param>
         /// <param name="drive">Drive representing the disc to get information from</param>
-        public abstract void GenerateSubmissionInfo(SubmissionInfo submissionInfo, string basePath, Drive drive);
+        /// <param name="includeArtifacts">True to include output files as encoded artifacts, false otherwise</param>
+        public abstract void GenerateSubmissionInfo(SubmissionInfo submissionInfo, string basePath, Drive drive, bool includeArtifacts);
 
         #endregion
 

--- a/MPF.Library/Data/BaseParameters.cs
+++ b/MPF.Library/Data/BaseParameters.cs
@@ -161,6 +161,13 @@ namespace MPF.Data
         public bool IsValid() => GenerateParameters() != null;
 
         /// <summary>
+        /// Generate a list of all log files generated
+        /// </summary>
+        /// <param name="basePath">Base filename and path to use for checking</param>
+        /// <returns>List of all log file paths, empty otherwise</returns>
+        public List<string> GetLogFilePaths(string basePath) => new List<string>();
+
+        /// <summary>
         /// Reset all special variables to have default values
         /// </summary>
         protected virtual void ResetValues() { }

--- a/MPF.Library/Data/BaseParameters.cs
+++ b/MPF.Library/Data/BaseParameters.cs
@@ -143,6 +143,13 @@ namespace MPF.Data
         public virtual string GetDefaultExtension(MediaType? mediaType) => null;
 
         /// <summary>
+        /// Generate a list of all log files generated
+        /// </summary>
+        /// <param name="basePath">Base filename and path to use for checking</param>
+        /// <returns>List of all log file paths, empty otherwise</returns>
+        public virtual List<string> GetLogFilePaths(string basePath) => new List<string>();
+
+        /// <summary>
         /// Get the MediaType from the current set of parameters
         /// </summary>
         /// <returns>MediaType value if successful, null on error</returns>
@@ -159,13 +166,6 @@ namespace MPF.Data
         /// </summary>
         /// <returns></returns>
         public bool IsValid() => GenerateParameters() != null;
-
-        /// <summary>
-        /// Generate a list of all log files generated
-        /// </summary>
-        /// <param name="basePath">Base filename and path to use for checking</param>
-        /// <returns>List of all log file paths, empty otherwise</returns>
-        public List<string> GetLogFilePaths(string basePath) => new List<string>();
 
         /// <summary>
         /// Reset all special variables to have default values

--- a/MPF.Library/Data/DumpEnvironment.cs
+++ b/MPF.Library/Data/DumpEnvironment.cs
@@ -480,7 +480,14 @@ namespace MPF.Data
 
             // Conpress the logs, if required
             if (Options.CompressLogFiles)
-                CompressLogFiles();
+            {
+                resultProgress?.Report(Result.Success("Compressing log files..."));
+                success = CompressLogFiles();
+                if (success)
+                    resultProgress?.Report(Result.Success("Compression complete!"));
+                else
+                    resultProgress?.Report(Result.Failure("Compression could not complete!"));
+            }
 
             resultProgress?.Report(Result.Success("Submission information process complete!"));
             return Result.Success();

--- a/MPF.Library/Data/DumpEnvironment.cs
+++ b/MPF.Library/Data/DumpEnvironment.cs
@@ -1305,7 +1305,7 @@ namespace MPF.Data
             // Prepare the necessary paths
             string outputFilename = Path.GetFileNameWithoutExtension(OutputFilename);
             string combinedBase = Path.Combine(OutputDirectory, outputFilename);
-            string archiveName = Path.Combine(OutputDirectory, "!dumpinfo.zip");
+            string archiveName = combinedBase + "_logs.zip";
 
             // Get the list of log files from the parameters object
             var files = Parameters.GetLogFilePaths(combinedBase);

--- a/MPF.Library/Data/DumpEnvironment.cs
+++ b/MPF.Library/Data/DumpEnvironment.cs
@@ -601,7 +601,7 @@ namespace MPF.Data
             };
 
             // Get specific tool output handling
-            Parameters.GenerateSubmissionInfo(info, combinedBase, this.Drive);
+            Parameters.GenerateSubmissionInfo(info, combinedBase, this.Drive, Options.OutputSubmissionJSON);
 
             // Get a list of matching IDs for each line in the DAT
             if (!string.IsNullOrEmpty(info.TracksAndWriteOffsets.ClrMameProData) && Options.HasRedumpLogin)

--- a/MPF.Library/Data/Options.cs
+++ b/MPF.Library/Data/Options.cs
@@ -286,6 +286,15 @@ namespace MPF.Data
             set { _settings["OutputSubmissionJSON"] = value.ToString(); }
         }
 
+        /// <summary>
+        /// Compress output log files to reduce space
+        /// </summary>
+        public bool CompressLogFiles
+        {
+            get { return GetBooleanSetting(_settings, "CompressLogFiles", true); }
+            set { _settings["CompressLogFiles"] = value.ToString(); }
+        }
+
         #endregion
 
         #region Skip Options

--- a/MPF.Library/Data/Options.cs
+++ b/MPF.Library/Data/Options.cs
@@ -291,7 +291,7 @@ namespace MPF.Data
         /// </summary>
         public bool CompressLogFiles
         {
-            get { return GetBooleanSetting(_settings, "CompressLogFiles", true); }
+            get { return GetBooleanSetting(_settings, "CompressLogFiles", false); }
             set { _settings["CompressLogFiles"] = value.ToString(); }
         }
 

--- a/MPF.Library/DiscImageCreator/Parameters.cs
+++ b/MPF.Library/DiscImageCreator/Parameters.cs
@@ -1225,7 +1225,6 @@ namespace MPF.DiscImageCreator
             var currentFiles = Directory.GetFiles(Path.GetDirectoryName(basePath));
             string cmdPath = currentFiles.FirstOrDefault(f => Regex.IsMatch(f, @"\d{8}T\d{6}"));
 
-            // TODO: Figure out how to get the filename for the former _cmd file...
             List<string> logFiles = new List<string>();
             switch (this.Type)
             {

--- a/MPF.Library/DiscImageCreator/Parameters.cs
+++ b/MPF.Library/DiscImageCreator/Parameters.cs
@@ -354,7 +354,7 @@ namespace MPF.DiscImageCreator
         }
 
         /// <inheritdoc/>
-        public override void GenerateSubmissionInfo(SubmissionInfo info, string basePath, Drive drive)
+        public override void GenerateSubmissionInfo(SubmissionInfo info, string basePath, Drive drive, bool includeArtifacts)
         {
             string outputDirectory = Path.GetDirectoryName(basePath);
 
@@ -708,53 +708,56 @@ namespace MPF.DiscImageCreator
                     break;
             }
 
-            // Fill in any artifacts that exist, Base64-encoded
-            //if (File.Exists(basePath + ".c2"))
-            //    info.Artifacts["c2"] = Convert.ToBase64String(File.ReadAllBytes(basePath + ".c2"));
-            if (File.Exists(basePath + "_c2Error.txt"))
-                info.Artifacts["c2Error"] = GetBase64(GetFullFile(basePath + "_c2Error.txt"));
-            if (File.Exists(basePath + ".ccd"))
-                info.Artifacts["ccd"] = GetBase64(GetFullFile(basePath + ".ccd"));
-            if (File.Exists(basePath + "_cmd.txt")) // TODO: Figure out how to read in the timestamp-named file
-                info.Artifacts["cmd"] = GetBase64(GetFullFile(basePath + "_cmd.txt"));
-            if (File.Exists(basePath + ".cue"))
-                info.Artifacts["cue"] = GetBase64(GetFullFile(basePath + ".cue"));
-            if (File.Exists(basePath + ".dat"))
-                info.Artifacts["dat"] = GetBase64(GetFullFile(basePath + ".dat"));
-            if (File.Exists(basePath + "_disc.txt"))
-                info.Artifacts["disc"] = GetBase64(GetFullFile(basePath + "_disc.txt"));
-            //if (File.Exists(Path.Combine(outputDirectory, "DMI.bin")))
-            //    info.Artifacts["dmi"] = Convert.ToBase64String(File.ReadAllBytes(Path.Combine(outputDirectory, "DMI.bin")));
-            if (File.Exists(basePath + "_drive.txt"))
-                info.Artifacts["drive"] = GetBase64(GetFullFile(basePath + "_drive.txt"));
-            if (File.Exists(basePath + "_img.cue"))
-                info.Artifacts["img_cue"] = GetBase64(GetFullFile(basePath + "_img.cue"));
-            if (File.Exists(basePath + ".img_EdcEcc.txt"))
-                info.Artifacts["img_EdcEcc"] = GetBase64(GetFullFile(basePath + ".img_EdcEcc.txt"));
-            if (File.Exists(basePath + ".img_EccEdc.txt"))
-                info.Artifacts["img_EdcEcc"] = GetBase64(GetFullFile(basePath + ".img_EccEdc.txt"));
-            if (File.Exists(basePath + "_mainError.txt"))
-                info.Artifacts["mainError"] = GetBase64(GetFullFile(basePath + "_mainError.txt"));
-            if (File.Exists(basePath + "_mainInfo.txt"))
-                info.Artifacts["mainInfo"] = GetBase64(GetFullFile(basePath + "_mainInfo.txt"));
-            //if (File.Exists(Path.Combine(outputDirectory, "PFI.bin")))
-            //    info.Artifacts["pfi"] = Convert.ToBase64String(File.ReadAllBytes(Path.Combine(outputDirectory, "PFI.bin")));
-            //if (File.Exists(Path.Combine(outputDirectory, "SS.bin")))
-            //    info.Artifacts["ss"] = Convert.ToBase64String(File.ReadAllBytes(Path.Combine(outputDirectory, "SS.bin")));
-            if (File.Exists(basePath + ".sub"))
-                info.Artifacts["sub"] = Convert.ToBase64String(File.ReadAllBytes(basePath + ".sub"));
-            if (File.Exists(basePath + "_subError.txt"))
-                info.Artifacts["subError"] = GetBase64(GetFullFile(basePath + "_subError.txt"));
-            if (File.Exists(basePath + "_subInfo.txt"))
-                info.Artifacts["subInfo"] = GetBase64(GetFullFile(basePath + "_subInfo.txt"));
-            if (File.Exists(basePath + "_subIntention.txt"))
-                info.Artifacts["subIntention"] = GetBase64(GetFullFile(basePath + "_subIntention.txt"));
-            //if (File.Exists(basePath + "_sub.txt"))
-            //    info.Artifacts["subReadable"] = GetBase64(GetFullFile(basePath + "_sub.txt"));
-            //if (File.Exists(basePath + "_subReadable.txt"))
-            //    info.Artifacts["subReadable"] = GetBase64(GetFullFile(basePath + "_subReadable.txt"));
-            if (File.Exists(basePath + "_volDesc.txt"))
-                info.Artifacts["volDesc"] = GetBase64(GetFullFile(basePath + "_volDesc.txt"));
+            // Fill in any artifacts that exist, Base64-encoded, if we need to
+            if (includeArtifacts)
+            {
+                //if (File.Exists(basePath + ".c2"))
+                //    info.Artifacts["c2"] = Convert.ToBase64String(File.ReadAllBytes(basePath + ".c2"));
+                if (File.Exists(basePath + "_c2Error.txt"))
+                    info.Artifacts["c2Error"] = GetBase64(GetFullFile(basePath + "_c2Error.txt"));
+                if (File.Exists(basePath + ".ccd"))
+                    info.Artifacts["ccd"] = GetBase64(GetFullFile(basePath + ".ccd"));
+                if (File.Exists(basePath + "_cmd.txt")) // TODO: Figure out how to read in the timestamp-named file
+                    info.Artifacts["cmd"] = GetBase64(GetFullFile(basePath + "_cmd.txt"));
+                if (File.Exists(basePath + ".cue"))
+                    info.Artifacts["cue"] = GetBase64(GetFullFile(basePath + ".cue"));
+                if (File.Exists(basePath + ".dat"))
+                    info.Artifacts["dat"] = GetBase64(GetFullFile(basePath + ".dat"));
+                if (File.Exists(basePath + "_disc.txt"))
+                    info.Artifacts["disc"] = GetBase64(GetFullFile(basePath + "_disc.txt"));
+                //if (File.Exists(Path.Combine(outputDirectory, "DMI.bin")))
+                //    info.Artifacts["dmi"] = Convert.ToBase64String(File.ReadAllBytes(Path.Combine(outputDirectory, "DMI.bin")));
+                if (File.Exists(basePath + "_drive.txt"))
+                    info.Artifacts["drive"] = GetBase64(GetFullFile(basePath + "_drive.txt"));
+                if (File.Exists(basePath + "_img.cue"))
+                    info.Artifacts["img_cue"] = GetBase64(GetFullFile(basePath + "_img.cue"));
+                if (File.Exists(basePath + ".img_EdcEcc.txt"))
+                    info.Artifacts["img_EdcEcc"] = GetBase64(GetFullFile(basePath + ".img_EdcEcc.txt"));
+                if (File.Exists(basePath + ".img_EccEdc.txt"))
+                    info.Artifacts["img_EdcEcc"] = GetBase64(GetFullFile(basePath + ".img_EccEdc.txt"));
+                if (File.Exists(basePath + "_mainError.txt"))
+                    info.Artifacts["mainError"] = GetBase64(GetFullFile(basePath + "_mainError.txt"));
+                if (File.Exists(basePath + "_mainInfo.txt"))
+                    info.Artifacts["mainInfo"] = GetBase64(GetFullFile(basePath + "_mainInfo.txt"));
+                //if (File.Exists(Path.Combine(outputDirectory, "PFI.bin")))
+                //    info.Artifacts["pfi"] = Convert.ToBase64String(File.ReadAllBytes(Path.Combine(outputDirectory, "PFI.bin")));
+                //if (File.Exists(Path.Combine(outputDirectory, "SS.bin")))
+                //    info.Artifacts["ss"] = Convert.ToBase64String(File.ReadAllBytes(Path.Combine(outputDirectory, "SS.bin")));
+                if (File.Exists(basePath + ".sub"))
+                    info.Artifacts["sub"] = Convert.ToBase64String(File.ReadAllBytes(basePath + ".sub"));
+                if (File.Exists(basePath + "_subError.txt"))
+                    info.Artifacts["subError"] = GetBase64(GetFullFile(basePath + "_subError.txt"));
+                if (File.Exists(basePath + "_subInfo.txt"))
+                    info.Artifacts["subInfo"] = GetBase64(GetFullFile(basePath + "_subInfo.txt"));
+                if (File.Exists(basePath + "_subIntention.txt"))
+                    info.Artifacts["subIntention"] = GetBase64(GetFullFile(basePath + "_subIntention.txt"));
+                //if (File.Exists(basePath + "_sub.txt"))
+                //    info.Artifacts["subReadable"] = GetBase64(GetFullFile(basePath + "_sub.txt"));
+                //if (File.Exists(basePath + "_subReadable.txt"))
+                //    info.Artifacts["subReadable"] = GetBase64(GetFullFile(basePath + "_subReadable.txt"));
+                if (File.Exists(basePath + "_volDesc.txt"))
+                    info.Artifacts["volDesc"] = GetBase64(GetFullFile(basePath + "_volDesc.txt"));
+            }
         }
 
         /// <inheritdoc/>

--- a/MPF.Library/DiscImageCreator/Parameters.cs
+++ b/MPF.Library/DiscImageCreator/Parameters.cs
@@ -1217,6 +1217,110 @@ namespace MPF.DiscImageCreator
         public override string GetDefaultExtension(MediaType? mediaType) => Converters.Extension(mediaType);
 
         /// <inheritdoc/>
+        public override List<string> GetLogFilePaths(string basePath)
+        {
+            var currentFiles = Directory.GetFiles(Path.GetDirectoryName(basePath));
+            string cmdPath = currentFiles.FirstOrDefault(f => Regex.IsMatch(f, @"\d{8}T\d{6}"));
+
+            // TODO: Figure out how to get the filename for the former _cmd file...
+            List<string> logFiles = new List<string>();
+            switch (this.Type)
+            {
+                case MediaType.CDROM:
+                case MediaType.GDROM: // TODO: Verify GD-ROM outputs this
+                    if (File.Exists($"{basePath}.c2"))
+                        logFiles.Add($"{basePath}.c2");
+                    if (File.Exists($"{basePath}_c2Error.txt"))
+                        logFiles.Add($"{basePath}_c2Error.txt");
+                    if (File.Exists($"{basePath}.ccd"))
+                        logFiles.Add($"{basePath}.ccd");
+                    if (cmdPath != null && File.Exists(cmdPath))
+                        logFiles.Add(cmdPath);
+                    if (File.Exists($"{basePath}_cmd.txt"))
+                        logFiles.Add($"{basePath}_cmd.txt");
+                    if (File.Exists($"{basePath}.dat"))
+                        logFiles.Add($"{basePath}.dat");
+                    if (File.Exists($"{basePath}.sub"))
+                        logFiles.Add($"{basePath}.sub");
+                    if (File.Exists($"{basePath}.subtmp"))
+                        logFiles.Add($"{basePath}.subtmp");
+                    if (File.Exists($"{basePath}_disc.txt"))
+                        logFiles.Add($"{basePath}_disc.txt");
+                    if (File.Exists($"{basePath}_drive.txt"))
+                        logFiles.Add($"{basePath}_drive.txt");
+                    if (File.Exists($"{basePath}_img.cue"))
+                        logFiles.Add($"{basePath}_img.cue");
+                    if (File.Exists($"{basePath}_mainError.txt"))
+                        logFiles.Add($"{basePath}_mainError.txt");
+                    if (File.Exists($"{basePath}_mainInfo.txt"))
+                        logFiles.Add($"{basePath}_mainInfo.txt");
+                    if (File.Exists($"{basePath}_sub.txt"))
+                        logFiles.Add($"{basePath}_sub.txt");
+                    if (File.Exists($"{basePath}_subError.txt"))
+                        logFiles.Add($"{basePath}_subError.txt");
+                    if (File.Exists($"{basePath}_subInfo.txt"))
+                        logFiles.Add($"{basePath}_subInfo.txt");
+                    if (File.Exists($"{basePath}_subIntention.txt"))
+                        logFiles.Add($"{basePath}_subIntention.txt");
+                    if (File.Exists($"{basePath}_subReadable.txt"))
+                        logFiles.Add($"{basePath}_subReadable.txt");
+                    if (File.Exists($"{basePath}_volDesc.txt"))
+                        logFiles.Add($"{basePath}_volDesc.txt");
+
+                    // Audio-only discs don't output these files
+                    if (!this.System.IsAudio())
+                    {
+                        if (File.Exists($"{basePath}.img_EdcEcc.txt"))
+                            logFiles.Add($"{basePath}.img_EdcEcc.txt");
+                        if (File.Exists($"{basePath}.img_EccEdc.txt"))
+                            logFiles.Add($"{basePath}.img_EccEdc.txt");
+                    }
+
+                    break;
+
+                case MediaType.DVD:
+                case MediaType.HDDVD:
+                case MediaType.BluRay:
+                case MediaType.NintendoGameCubeGameDisc:
+                case MediaType.NintendoWiiOpticalDisc:
+                    if (cmdPath != null && File.Exists(cmdPath))
+                        logFiles.Add(cmdPath);
+                    if (File.Exists($"{basePath}_cmd.txt"))
+                        logFiles.Add($"{basePath}_cmd.txt");
+                    if (File.Exists($"{basePath}.dat"))
+                        logFiles.Add($"{basePath}.dat");
+                    if (File.Exists($"{basePath}_disc.txt"))
+                        logFiles.Add($"{basePath}_disc.txt");
+                    if (File.Exists($"{basePath}_drive.txt"))
+                        logFiles.Add($"{basePath}_drive.txt");
+                    if (File.Exists($"{basePath}_mainError.txt"))
+                        logFiles.Add($"{basePath}_mainError.txt");
+                    if (File.Exists($"{basePath}_mainInfo.txt"))
+                        logFiles.Add($"{basePath}_mainInfo.txt");
+                    if (File.Exists($"{basePath}_volDesc.txt"))
+                        logFiles.Add($"{basePath}_volDesc.txt");
+
+                    break;
+
+                case MediaType.FloppyDisk:
+                case MediaType.HardDisk:
+                    // TODO: Determine what outputs come out from a HDD, SD, etc.
+                    if (cmdPath != null && File.Exists(cmdPath))
+                        logFiles.Add(cmdPath);
+                    if (File.Exists($"{basePath}_cmd.txt"))
+                        logFiles.Add($"{basePath}_cmd.txt");
+                    if (File.Exists($"{basePath}.dat"))
+                        logFiles.Add($"{basePath}.dat");
+                    if (File.Exists($"{basePath}_disc.txt"))
+                        logFiles.Add($"{basePath}_disc.txt");
+
+                    break;
+            }
+
+            return logFiles;
+        }
+
+        /// <inheritdoc/>
         public override MediaType? GetMediaType() => Converters.ToMediaType(BaseCommand);
 
         /// <inheritdoc/>

--- a/MPF.Library/MPF.Library.csproj
+++ b/MPF.Library/MPF.Library.csproj
@@ -71,6 +71,7 @@
       <IncludeAssets>runtime; compile; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.Management" Version="5.0.0" />
   </ItemGroup>
   

--- a/MPF.Library/UmdImageCreator/Parameters.cs
+++ b/MPF.Library/UmdImageCreator/Parameters.cs
@@ -56,7 +56,7 @@ namespace MPF.UmdImageCreator
         }
 
         /// <inheritdoc/>
-        public override void GenerateSubmissionInfo(SubmissionInfo info, string basePath, Drive drive)
+        public override void GenerateSubmissionInfo(SubmissionInfo info, string basePath, Drive drive, bool includeArtifacts)
         {
             // Extract info based generically on MediaType
             switch (this.Type)
@@ -86,15 +86,18 @@ namespace MPF.UmdImageCreator
                     break;
             }
 
-            // Fill in any artifacts that exist, Base64-encoded
-            if (File.Exists(basePath + "_disc.txt"))
-                info.Artifacts["disc"] = GetBase64(GetFullFile(basePath + "_disc.txt"));
-            if (File.Exists(basePath + "_mainError.txt"))
-                info.Artifacts["mainError"] = GetBase64(GetFullFile(basePath + "_mainError.txt"));
-            if (File.Exists(basePath + "_mainInfo.txt"))
-                info.Artifacts["mainInfo"] = GetBase64(GetFullFile(basePath + "_mainInfo.txt"));
-            if (File.Exists(basePath + "_volDesc.txt"))
-                info.Artifacts["volDesc"] = GetBase64(GetFullFile(basePath + "_volDesc.txt"));
+            // Fill in any artifacts that exist, Base64-encoded, if we need to
+            if (includeArtifacts)
+            {
+                if (File.Exists(basePath + "_disc.txt"))
+                    info.Artifacts["disc"] = GetBase64(GetFullFile(basePath + "_disc.txt"));
+                if (File.Exists(basePath + "_mainError.txt"))
+                    info.Artifacts["mainError"] = GetBase64(GetFullFile(basePath + "_mainError.txt"));
+                if (File.Exists(basePath + "_mainInfo.txt"))
+                    info.Artifacts["mainInfo"] = GetBase64(GetFullFile(basePath + "_mainInfo.txt"));
+                if (File.Exists(basePath + "_volDesc.txt"))
+                    info.Artifacts["volDesc"] = GetBase64(GetFullFile(basePath + "_volDesc.txt"));
+            }
         }
 
         #endregion

--- a/MPF.Library/UmdImageCreator/Parameters.cs
+++ b/MPF.Library/UmdImageCreator/Parameters.cs
@@ -100,6 +100,28 @@ namespace MPF.UmdImageCreator
             }
         }
 
+        /// <inheritdoc/>
+        public override List<string> GetLogFilePaths(string basePath)
+        {
+            List<string> logFiles = new List<string>();
+            switch (this.Type)
+            {
+                case MediaType.UMD:
+                    if (File.Exists($"{basePath}_disc.txt"))
+                        logFiles.Add($"{basePath}_disc.txt");
+                    if (File.Exists($"{basePath}_mainError.txt"))
+                        logFiles.Add($"{basePath}_mainError.txt");
+                    if (File.Exists($"{basePath}_mainInfo.txt"))
+                        logFiles.Add($"{basePath}_mainInfo.txt");
+                    if (File.Exists($"{basePath}_volDesc.txt"))
+                        logFiles.Add($"{basePath}_volDesc.txt");
+
+                    break;
+            }
+
+            return logFiles;
+        }
+
         #endregion
 
         #region Information Extraction Methods

--- a/MPF/Windows/OptionsWindow.xaml
+++ b/MPF/Windows/OptionsWindow.xaml
@@ -109,6 +109,11 @@
                                      IsChecked="{Binding Path=UIOptions.Options.OutputSubmissionJSON}"
                                      ToolTip="Enable outputting a compressed JSON version of the submission info" Margin="0,4"
                                      />
+
+                                <CheckBox VerticalAlignment="Center" Content="Compress Log Files"
+                                     IsChecked="{Binding Path=UIOptions.Options.CompressLogFiles}"
+                                     ToolTip="Compress output log files to reduce space Margin="0,4"
+                                     />
                             </UniformGrid>
                         </GroupBox>
                         

--- a/MPF/Windows/OptionsWindow.xaml
+++ b/MPF/Windows/OptionsWindow.xaml
@@ -112,7 +112,7 @@
 
                                 <CheckBox VerticalAlignment="Center" Content="Compress Log Files"
                                      IsChecked="{Binding Path=UIOptions.Options.CompressLogFiles}"
-                                     ToolTip="Compress output log files to reduce space Margin="0,4"
+                                     ToolTip="Compress output log files to reduce space" Margin="0,4"
                                      />
                             </UniformGrid>
                         </GroupBox>


### PR DESCRIPTION
This has been a long-requested feature that we finally have room in the options menu to support. This new option allows for all files considered "log files" to be compressed into a zip file after dumping, deleting the uncompressed versions. This helps save on space and helps with submissions. This option currently defaults to disabled.

Both Aaru and DiscImageCreator currently support this, as they're the only ones that have log files and dumping support combined. This has been tested to ensure that all log files (including the dreaded new command file in DIC) are archived. **Edit:** As of one of the more recent commits, Check support has been added so compression can be applied after the fact. This also means that both CleanRip and UmdImageCreator both can have their logs compressed as well.

This also fixes another related issue where if users don't want to output the JSON, we shouldn't collect the artifact information. This can potentially lead to memory issues.

Fixes https://github.com/SabreTools/MPF/issues/22