### PR TITLE
Fix for high cpu usage, issue with loop.

### DIFF
--- a/MPF.Library/Data/ProcessingQueue.cs
+++ b/MPF.Library/Data/ProcessingQueue.cs
@@ -61,7 +61,7 @@ namespace MPF.Data
                 {
                     if (this.TokenSource.IsCancellationRequested)
                         break;
-
+                    System.Threading.Thread.Sleep(10);
                     continue;
                 }
 


### PR DESCRIPTION
When doing nothing, MPF maxes out a CPU core due to a loop. This wasnt in 1.18, so its fairly recent addition. I have just added a small sleep, but you may want to do it another way.

Either way, fix stops the loop maxing out a core.