### PR TITLE
Fixed launching MPF in Windows 7.

### DIFF
--- a/MPF/App.xaml
+++ b/MPF/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:MPF"
-             xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2" x:Class="MPF.App"
+             xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero" x:Class="MPF.App"
              StartupUri="Windows\MainWindow.xaml">
     <Application.Resources>
 

--- a/MPF/MPF.csproj
+++ b/MPF/MPF.csproj
@@ -54,7 +54,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="PresentationFramework.Aero2" />
+    <Reference Include="PresentationFramework.Aero" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Just had to "downgrade" the Aero reference and it now launches and runs just fine in Windows 7.