### PR TITLE
Added a button to quickly update the volume label and dump path.

### DIFF
--- a/MPF/ViewModels/MainViewModel.cs
+++ b/MPF/ViewModels/MainViewModel.cs
@@ -1461,7 +1461,7 @@ namespace MPF.GUI.ViewModels
         /// <summary>
         /// Handler for UpdateVolumeLabel Click event
         /// </summary>
-        private void UpdateVolumeLabelClick(object sender, RoutedEventArgs w)
+        private void UpdateVolumeLabelClick(object sender, RoutedEventArgs e)
         {
             if (_canExecuteSelectionChanged)
                 InitializeUIValues(removeEventHandlers: true, rescanDrives: false);

--- a/MPF/ViewModels/MainViewModel.cs
+++ b/MPF/ViewModels/MainViewModel.cs
@@ -76,6 +76,7 @@ namespace MPF.GUI.ViewModels
             // Disable buttons until we load fully
             App.Instance.StartStopButton.IsEnabled = false;
             App.Instance.MediaScanButton.IsEnabled = false;
+            App.Instance.UpdateVolumeLabel.IsEnabled = false;
             App.Instance.CopyProtectScanButton.IsEnabled = false;
 
             // Add the click handlers to the UI
@@ -105,6 +106,7 @@ namespace MPF.GUI.ViewModels
 
             // Always enable the media scan
             App.Instance.MediaScanButton.IsEnabled = true;
+            App.Instance.UpdateVolumeLabel.IsEnabled = true;
 
             // Populate the list of drives and add it to the combo box
             Drives = Drive.CreateListOfDrives(App.Options.IgnoreFixedDrives);
@@ -548,6 +550,7 @@ namespace MPF.GUI.ViewModels
             App.Instance.CopyProtectScanButton.Click += CopyProtectScanButtonClick;
             App.Instance.EnableParametersCheckBox.Click += EnableParametersCheckBoxClick;
             App.Instance.MediaScanButton.Click += MediaScanButtonClick;
+            App.Instance.UpdateVolumeLabel.Click += UpdateVolumeLabelClick;
             App.Instance.OutputDirectoryBrowseButton.Click += OutputDirectoryBrowseButtonClick;
             App.Instance.StartStopButton.Click += StartStopButtonClick;
 
@@ -612,6 +615,7 @@ namespace MPF.GUI.ViewModels
             App.Instance.EnableParametersCheckBox.IsEnabled = false;
             App.Instance.StartStopButton.Content = Interface.StopDumping;
             App.Instance.MediaScanButton.IsEnabled = false;
+            App.Instance.UpdateVolumeLabel.IsEnabled = false;
             App.Instance.CopyProtectScanButton.IsEnabled = false;
         }
 
@@ -631,6 +635,7 @@ namespace MPF.GUI.ViewModels
             App.Instance.EnableParametersCheckBox.IsEnabled = true;
             App.Instance.StartStopButton.Content = Interface.StartDumping;
             App.Instance.MediaScanButton.IsEnabled = true;
+            App.Instance.UpdateVolumeLabel.IsEnabled = true;
             App.Instance.CopyProtectScanButton.IsEnabled = true;
         }
 
@@ -1006,7 +1011,7 @@ namespace MPF.GUI.ViewModels
                     App.Instance.DriveLetterComboBox.SelectedIndex = driveIndex;
             }
             catch { }
-            
+
             int driveSpeed = Env.Parameters.Speed ?? -1;
             if (driveSpeed > 0)
                 App.Instance.DriveSpeedComboBox.SelectedValue = driveSpeed;
@@ -1067,6 +1072,7 @@ namespace MPF.GUI.ViewModels
                 App.Instance.StatusLabel.Content = "Scanning for copy protection... this might take a while!";
                 App.Instance.StartStopButton.IsEnabled = false;
                 App.Instance.MediaScanButton.IsEnabled = false;
+                App.Instance.UpdateVolumeLabel.IsEnabled = false;
                 App.Instance.CopyProtectScanButton.IsEnabled = false;
 
                 var progress = new Progress<ProtectionProgress>();
@@ -1096,6 +1102,7 @@ namespace MPF.GUI.ViewModels
                 App.Instance.StatusLabel.Content = tempContent;
                 App.Instance.StartStopButton.IsEnabled = ShouldEnableDumpingButton();
                 App.Instance.MediaScanButton.IsEnabled = true;
+                App.Instance.UpdateVolumeLabel.IsEnabled = true;
                 App.Instance.CopyProtectScanButton.IsEnabled = true;
             }
         }
@@ -1450,6 +1457,15 @@ namespace MPF.GUI.ViewModels
         /// </summary>
         private void MediaScanButtonClick(object sender, RoutedEventArgs e) =>
             InitializeUIValues(removeEventHandlers: true, rescanDrives: true);
+
+        /// <summary>
+        /// Handler for UpdateVolumeLabel Click event
+        /// </summary>
+        private void UpdateVolumeLabelClick(object sender, RoutedEventArgs w)
+        {
+            if (_canExecuteSelectionChanged)
+                InitializeUIValues(removeEventHandlers: true, rescanDrives: false);
+        }
 
         /// <summary>
         /// Handler for MediaTypeComboBox SelectionChanged event

--- a/MPF/Windows/MainWindow.xaml
+++ b/MPF/Windows/MainWindow.xaml
@@ -163,10 +163,12 @@
             </GroupBox>
 
             <GroupBox Margin="5,5,5,5" HorizontalAlignment="Stretch" Header="Controls">
-                <UniformGrid Columns="3" Margin="5,5,5,5">
+                <UniformGrid Columns="4" Margin="5,5,5,5">
                     <Button x:Name="StartStopButton" Height="22" Width="125" VerticalAlignment="Center" HorizontalAlignment="Center" IsDefault="True" Content="Start Dumping"
                             IsEnabled="False" Style="{DynamicResource CustomButtonStyle}" />
                     <Button x:Name="MediaScanButton" Height="22" Width="125" VerticalAlignment="Center" HorizontalAlignment="Center" Content="Scan for discs"
+                            Style="{DynamicResource CustomButtonStyle}" />
+                    <Button x:Name="UpdateVolumeLabel" Height="22" Width="125" VerticalAlignment="Center" HorizontalAlignment="Center" Content="Update Label"
                             Style="{DynamicResource CustomButtonStyle}" />
                     <Button x:Name="CopyProtectScanButton" Height="22" Width="125" VerticalAlignment="Center" HorizontalAlignment="Center" Content="Scan for protection"
                             Style="{DynamicResource CustomButtonStyle}" />


### PR DESCRIPTION
Behaves identically to switching the selected drive combo box. (Calls the InitializeUIValues method with rescanDrives set to false.)

Perhaps it might be better if this button assumed no auto-scan and just updates the label always skipping SystemType detection?