### PR TITLE
Add PS4 detection for discs that do not use `PS4VOLUME` label

### DIFF
--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -296,6 +296,23 @@ namespace MPF.Core.Data
             }
             catch { }
 
+            // Sony PlayStation 4
+            // There are more possible paths that could be checked.
+            //  There are some entries that can be found on most PS4 discs:
+            //    "/app/GAME_SERIAL/app.pkg"
+            //    "/bd/param.sfo"
+            //    "/license/rif"
+            // There are also extra files that can be found on some discs:
+            //    "/patch/GAME_SERIAL/patch.pkg" can be found in Redump entry 66816.
+            //        Originally on disc as "/patch/CUSA11302/patch.pkg".
+            //        Is used as an on-disc update for the base game app without needing to get update from the internet.
+            //    "/addcont/GAME_SERIAL/CONTENT_ID/ac.pkg" can be found in Redump entry 97619.
+            //        Originally on disc as "/addcont/CUSA00288/FFXIVEXPS400001A/ac.pkg".
+            if (File.Exists(Path.Combine(drivePath, "PS4", "UPDATE", "PS4UPDATE.PUP")))
+            {
+                return RedumpSystem.SonyPlayStation4;
+            }
+
             // V.Tech V.Flash / V.Smile Pro
             if (File.Exists(Path.Combine(drivePath, "0SYSTEM")))
             {


### PR DESCRIPTION
Adds PS4 detection based on the existence of `PS4/UPDATE/PS4UPDATE.PUP`, and also added some comments about other files that can be found on PS4 discs.