### PR TITLE
Add + to positive offsets in a better way

### DIFF
--- a/MPF.Library/InfoTool.cs
+++ b/MPF.Library/InfoTool.cs
@@ -821,8 +821,8 @@ namespace MPF.Library
                     AddIfExists(output, Template.DATField, info.TracksAndWriteOffsets.ClrMameProData + "\n", 1);
                     AddIfExists(output, Template.CuesheetField, info.TracksAndWriteOffsets.Cuesheet, 1);
                     string offset = info.TracksAndWriteOffsets.OtherWriteOffsets;
-                    if (offset?.StartsWith("-") == false)
-                        offset = $"+{offset}";
+                    if (Int32.TryParse(offset, out int i))
+                        offset = i.ToString("+#;-#;0");
 
                     AddIfExists(output, Template.WriteOffsetField, offset, 1);
                 }


### PR DESCRIPTION
Suppresses excessive "+".
I don't know C#, please modify accordingly.

```c#
string[] offsets = new string[] { "-1", "0", "1", "+1", "", "abc", null };

// current
foreach (string o in offsets) {
    string offset = o;
    if (offset?.StartsWith("-") == false)
        offset = $"+{offset}";
    System.Console.Write("[" + offset + "] ");
}
//=> [-1] [+0] [+1] [++1] [+] [+abc] [] 

System.Console.WriteLine();

// this PR
foreach (string o in offsets) {
    string offset = o;
    if (Int32.TryParse(offset, out int i))
        offset = i.ToString("+#;-#;0");
    System.Console.Write("[" + offset + "] ");
}
//=> [-1] [0] [+1] [+1] [] [abc] [] 
```
