### PR TITLE
General UI Cleanup

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -7,7 +7,8 @@
 - Add .NET 6.0 to tests, remove msbuild args
 - Add HD-DVD to speed definitions
 - Add PS3 internal serial and version parsing (tjanas)
--  Update Nuget packages to newest stable
+- Update Nuget packages to newest stable
+- Simplify path selection in UI
 
 ### 2.4 (2022-10-26)
 - Update to DIC 20211001

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -10,6 +10,7 @@
 - Update Nuget packages to newest stable
 - Simplify path selection in UI
 - Fix broken normalization test
+- Update drive info before dumping
 
 ### 2.4 (2022-10-26)
 - Update to DIC 20211001

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -9,6 +9,7 @@
 - Add PS3 internal serial and version parsing (tjanas)
 - Update Nuget packages to newest stable
 - Simplify path selection in UI
+- Fix broken normalization test
 
 ### 2.4 (2022-10-26)
 - Update to DIC 20211001

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -7,6 +7,7 @@
 - Add .NET 6.0 to tests, remove msbuild args
 - Add HD-DVD to speed definitions
 - Add PS3 internal serial and version parsing (tjanas)
+-  Update Nuget packages to newest stable
 
 ### 2.4 (2022-10-26)
 - Update to DIC 20211001

--- a/MPF.Check/MPF.Check.csproj
+++ b/MPF.Check/MPF.Check.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BurnOutSharp" PrivateAssets="build; analyzers" ExcludeAssets="contentFiles" Version="2.3.4" GeneratePathProperty="true">
+    <PackageReference Include="BurnOutSharp" PrivateAssets="build; analyzers" ExcludeAssets="contentFiles" Version="2.5.0" GeneratePathProperty="true">
       <IncludeAssets>runtime; compile; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Unclassified.NetRevisionTask" Version="0.4.3">

--- a/MPF.Check/Program.cs
+++ b/MPF.Check/Program.cs
@@ -59,7 +59,7 @@ namespace MPF.Check
                 if (!string.IsNullOrWhiteSpace(path))
                     drive = Drive.Create(null, path);
 
-                var env = new DumpEnvironment(options, "", filepath, drive, knownSystem, mediaType, null);
+                var env = new DumpEnvironment(options, filepath, drive, knownSystem, mediaType, null);
 
                 // Finally, attempt to do the output dance
                 var result = env.VerifyAndSaveDumpOutput(resultProgress, protectionProgress).ConfigureAwait(false).GetAwaiter().GetResult();

--- a/MPF.Core/MPF.Core.csproj
+++ b/MPF.Core/MPF.Core.csproj
@@ -56,9 +56,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
-    <PackageReference Include="System.Management" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.Management" Version="7.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 

--- a/MPF.Library/MPF.Library.csproj
+++ b/MPF.Library/MPF.Library.csproj
@@ -28,10 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BurnOutSharp" PrivateAssets="build; analyzers" ExcludeAssets="contentFiles" Version="2.3.4" GeneratePathProperty="true">
+    <PackageReference Include="BurnOutSharp" PrivateAssets="build; analyzers" ExcludeAssets="contentFiles" Version="2.5.0" GeneratePathProperty="true">
       <IncludeAssets>runtime; compile; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />

--- a/MPF.Modules/BaseParameters.cs
+++ b/MPF.Modules/BaseParameters.cs
@@ -242,7 +242,7 @@ namespace MPF.Modules
         /// </summary>
         /// <param name="parameters">String possibly representing parameters</param>
         /// <returns>True if the parameters were set correctly, false otherwise</returns>
-        protected virtual bool ValidateAndSetParameters(string parameters) => true;
+        protected virtual bool ValidateAndSetParameters(string parameters) => !string.IsNullOrWhiteSpace(parameters);
 
         #endregion
 

--- a/MPF.Test/Library/DumpEnvironmentTests.cs
+++ b/MPF.Test/Library/DumpEnvironmentTests.cs
@@ -24,7 +24,7 @@ namespace MPF.Test.Library
                 ? Drive.Create(InternalDriveType.Floppy, letter.ToString())
                 : Drive.Create(InternalDriveType.Optical, letter.ToString());
 
-            var env = new DumpEnvironment(options, string.Empty, string.Empty, drive, RedumpSystem.IBMPCcompatible, mediaType, parameters);
+            var env = new DumpEnvironment(options, string.Empty, drive, RedumpSystem.IBMPCcompatible, mediaType, parameters);
 
             bool actual = env.ParametersValid();
             Assert.Equal(expected, actual);

--- a/MPF.Test/Library/InfoToolTests.cs
+++ b/MPF.Test/Library/InfoToolTests.cs
@@ -51,7 +51,7 @@ namespace MPF.Test.Library
         [InlineData(null, null)]
         [InlineData(" ", " ")]
         [InlineData("super\\blah.bin", "super\\blah.bin")]
-        [InlineData("super\\hero\\blah.bin", "super\\hero\\\blah.bin")]
+        [InlineData("super\\hero\\blah.bin", "super\\hero\\blah.bin")]
         [InlineData("super.hero\\blah.bin", "super.hero\\blah.bin")]
         [InlineData("superhero\\blah.rev.bin", "superhero\\blah.rev.bin")]
         [InlineData("super&hero\\blah.bin", "super&hero\\blah.bin")]

--- a/MPF.Test/Library/InfoToolTests.cs
+++ b/MPF.Test/Library/InfoToolTests.cs
@@ -48,19 +48,18 @@ namespace MPF.Test.Library
         }
 
         [Theory]
-        [InlineData(null, null, null, null)]
-        [InlineData(" ", "", " ", "")]
-        [InlineData("super", "blah.bin", "super", "blah.bin")]
-        [InlineData("super\\hero", "blah.bin", "super\\hero", "blah.bin")]
-        [InlineData("super.hero", "blah.bin", "super.hero", "blah.bin")]
-        [InlineData("superhero", "blah.rev.bin", "superhero", "blah.rev.bin")]
-        [InlineData("super&hero", "blah.bin", "super&hero", "blah.bin")]
-        [InlineData("superhero", "blah&foo.bin", "superhero", "blah&foo.bin")]
-        public void NormalizeOutputPathsTest(string outputDirectory, string outputFilename, string expectedOutputDirectory, string expectedOutputFilename)
+        [InlineData(null, null)]
+        [InlineData(" ", " ")]
+        [InlineData("super\\blah.bin", "super\\blah.bin")]
+        [InlineData("super\\hero\\blah.bin", "super\\hero\\\blah.bin")]
+        [InlineData("super.hero\\blah.bin", "super.hero\\blah.bin")]
+        [InlineData("superhero\\blah.rev.bin", "superhero\\blah.rev.bin")]
+        [InlineData("super&hero\\blah.bin", "super&hero\\blah.bin")]
+        [InlineData("superhero\\blah&foo.bin", "superhero\\blah&foo.bin")]
+        public void NormalizeOutputPathsTest(string outputPath, string expectedPath)
         {
-            (string actualOutputDirectory, string actualOutputFilename) = InfoTool.NormalizeOutputPaths(outputDirectory, outputFilename);
-            Assert.Equal(expectedOutputDirectory, actualOutputDirectory);
-            Assert.Equal(expectedOutputFilename, actualOutputFilename);
+            string actualPath = InfoTool.NormalizeOutputPaths(outputPath);
+            Assert.Equal(expectedPath, actualPath);
         }
 
         [Fact]

--- a/MPF.Test/MPF.Test.csproj
+++ b/MPF.Test/MPF.Test.csproj
@@ -35,12 +35,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="xunit.analyzers" Version="1.0.0" />
+    <PackageReference Include="xunit.analyzers" Version="1.1.0" />
     <PackageReference Include="xunit.assert" Version="2.4.2" />
     <PackageReference Include="xunit.core" Version="2.4.2" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.2" />

--- a/MPF.UI.Core/MPF.UI.Core.csproj
+++ b/MPF.UI.Core/MPF.UI.Core.csproj
@@ -20,6 +20,7 @@
     <NrtRevisionFormat>$(Version)-{chash:8}</NrtRevisionFormat>
     <NrtResolveSimpleAttributes>true</NrtResolveSimpleAttributes>
     <NrtShowRevision>false</NrtShowRevision>
+    <UserSecretsId>27abb4ca-bf7a-431e-932f-49153303d5ff</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MPF/MPF.csproj
+++ b/MPF/MPF.csproj
@@ -27,10 +27,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BurnOutSharp" PrivateAssets="build; analyzers" ExcludeAssets="contentFiles" Version="2.3.4" GeneratePathProperty="true">
+    <PackageReference Include="BurnOutSharp" PrivateAssets="build; analyzers" ExcludeAssets="contentFiles" Version="2.5.0" GeneratePathProperty="true">
       <IncludeAssets>runtime; compile; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     <PackageReference Include="Unclassified.NetRevisionTask" Version="0.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MPF/ViewModels/MainViewModel.cs
+++ b/MPF/ViewModels/MainViewModel.cs
@@ -1195,6 +1195,10 @@ namespace MPF.UI.ViewModels
                 // Disable all UI elements apart from dumping button
                 DisableAllUIElements();
 
+                // Refresh the drive, if it wasn't null
+                if (Env.Drive != null)
+                    Env.Drive.RefreshDrive();
+
                 // Output to the label and log
                 App.Instance.StatusLabel.Text = "Starting dumping process... Please wait!";
                 App.Logger.LogLn("Starting dumping process... Please wait!");

--- a/MPF/Windows/MainWindow.xaml
+++ b/MPF/Windows/MainWindow.xaml
@@ -119,7 +119,6 @@
                         <RowDefinition/>
                         <RowDefinition/>
                         <RowDefinition/>
-                        <RowDefinition/>
                     </Grid.RowDefinitions>
 
                     <Label x:Name="SystemMediaTypeLabel" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Content="System/Media Type" />
@@ -136,16 +135,13 @@
                     </ComboBox>
                     <ComboBox x:Name="MediaTypeComboBox" Grid.Row="0" Grid.Column="1" Height="22" Width="140" HorizontalAlignment="Right" Style="{DynamicResource CustomComboBoxStyle}" />
 
-                    <Label x:Name="OutputFilenameLabel" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Content="Output Filename"/>
-                    <TextBox x:Name="OutputFilenameTextBox" Grid.Row="1" Grid.Column="1" Height="22" VerticalContentAlignment="Center" />
-
-                    <Label x:Name="OutputDirectoryLabel" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Content="Output Directory"/>
-                    <TextBox x:Name="OutputDirectoryTextBox" Grid.Row="2" Grid.Column="1" Height="22" Width="345" HorizontalAlignment="Left" VerticalContentAlignment="Center" />
-                    <Button x:Name="OutputDirectoryBrowseButton" Grid.Row="2" Grid.Column="1" Height="22" Width="50" HorizontalAlignment="Right" Content="Browse"
+                    <Label x:Name="OutputPathLabel" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Content="Output Path"/>
+                    <TextBox x:Name="OutputPathTextBox" Grid.Row="1" Grid.Column="1" Height="22" Width="345" HorizontalAlignment="Left" VerticalContentAlignment="Center" />
+                    <Button x:Name="OutputPathBrowseButton" Grid.Row="1" Grid.Column="1" Height="22" Width="50" HorizontalAlignment="Right" Content="Browse"
                             Style="{DynamicResource CustomButtonStyle}"/>
 
-                    <Label x:Name="DriveLetterLabel" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Content="Drive Letter"/>
-                    <ComboBox x:Name="DriveLetterComboBox" Grid.Row="3" Grid.Column="1" Height="22" Width="60" HorizontalAlignment="Left" Style="{DynamicResource CustomComboBoxStyle}">
+                    <Label x:Name="DriveLetterLabel" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Content="Drive Letter"/>
+                    <ComboBox x:Name="DriveLetterComboBox" Grid.Row="2" Grid.Column="1" Height="22" Width="60" HorizontalAlignment="Left" Style="{DynamicResource CustomComboBoxStyle}">
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding Letter}" />
@@ -153,12 +149,12 @@
                         </ComboBox.ItemTemplate>
                     </ComboBox>
 
-                    <Label x:Name="DriveSpeedLabel" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Content="Drive Speed"/>
-                    <ComboBox x:Name="DriveSpeedComboBox" Grid.Row="4" Grid.Column="1" Height="22" Width="60" HorizontalAlignment="Left" Style="{DynamicResource CustomComboBoxStyle}" />
+                    <Label x:Name="DriveSpeedLabel" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Content="Drive Speed"/>
+                    <ComboBox x:Name="DriveSpeedComboBox" Grid.Row="3" Grid.Column="1" Height="22" Width="60" HorizontalAlignment="Left" Style="{DynamicResource CustomComboBoxStyle}" />
 
-                    <Label x:Name="ParametersLabel" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Content="Parameters"/>
-                    <TextBox x:Name="ParametersTextBox" Grid.Row="5" Grid.Column="1" Height="22" Width="370" HorizontalAlignment="Left" IsEnabled="False" VerticalContentAlignment="Center" />
-                    <CheckBox x:Name="EnableParametersCheckBox" Grid.Row="5" Grid.Column="1" Height="22" HorizontalAlignment="Right" IsChecked="False" />
+                    <Label x:Name="ParametersLabel" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Content="Parameters"/>
+                    <TextBox x:Name="ParametersTextBox" Grid.Row="4" Grid.Column="1" Height="22" Width="370" HorizontalAlignment="Left" IsEnabled="False" VerticalContentAlignment="Center" />
+                    <CheckBox x:Name="EnableParametersCheckBox" Grid.Row="4" Grid.Column="1" Height="22" HorizontalAlignment="Right" IsChecked="False" />
                 </Grid>
             </GroupBox>
 


### PR DESCRIPTION
This PR does the following:
- Updates Nuget packages to newest version
- Combines output directory and filename into an output path box (fixes https://github.com/SabreTools/MPF/issues/431)
- Cleanup internal normalization, including replacing `.` with `_` for DIC, again (fixes https://github.com/SabreTools/MPF/issues/437)
- Force drive update before dump to ensure volume label is set (fixes https://github.com/SabreTools/MPF/issues/430)
- Show a popup box if you have empty parameters when trying to dump