### PR TITLE
Improve write offset detection for redumper

### DIFF
--- a/MPF.Modules/Redumper/Parameters.cs
+++ b/MPF.Modules/Redumper/Parameters.cs
@@ -1008,12 +1008,13 @@ namespace MPF.Modules.Redumper
                     if (sr.EndOfStream)
                         return null;
 
-                    sr.ReadLine(); // * disc detected
-
-                    // Now read the offset
-                    string line = sr.ReadLine();
-                    if (line.StartsWith("disc write offset:"))
-                        return line.Substring("disc write offset: ".Length).Trim();
+                    // We skip during detection and get the write offset
+                    string line;
+                    while (!sr.EndOfStream && !(line = sr.ReadLine().TrimStart()).StartsWith("detection complete"))
+                    {
+                        if (line.StartsWith("disc write offset:"))
+                            return line.Substring("disc write offset: ".Length).Trim();
+                    }
 
                     // We couldn't detect it then
                     return null;


### PR DESCRIPTION
Skip all lines in the detection.

# Some samples
## Audio
```
detecting offset
audio silence detection... done
Perfect Audio Offset (silence level: 0): [-28707 .. +15478]
warning: fallback offset 0 applied
disc write offset: +0
detection complete (time: 15s)
```

## Audio
```
detecting offset
audio silence detection... done
Perfect Audio Offset (silence level: 0): -12
Perfect Audio Offset applied
disc write offset: -12
detection complete (time: 17s)
```

## PC
```
detecting offset
data track detected
disc write offset: -12
detection complete (time: 0s)
```
