### PR TITLE
Originally intended behaviour of the Update Label button.

### DIFF
--- a/MPF.Core/Data/Options.cs
+++ b/MPF.Core/Data/Options.cs
@@ -88,6 +88,15 @@ namespace MPF.Core.Data
         }
 
         /// <summary>
+        /// Fast update label - Skips disc checks and updates path only
+        /// </summary>
+        public bool FastUpdateLabel
+        {
+            get { return GetBooleanSetting(_settings, "FastUpdateLabel", false); }
+            set { _settings["FastUpdateLabel"] = value.ToString(); }
+        }
+
+        /// <summary>
         /// Default output path for dumps
         /// </summary>
         public string DefaultOutputPath

--- a/MPF/ViewModels/MainViewModel.cs
+++ b/MPF/ViewModels/MainViewModel.cs
@@ -588,26 +588,16 @@ namespace MPF.UI.ViewModels
                 App.Instance.EnableParametersCheckBox.Checked += EnableParametersCheckBoxClick;
             }
 
-            // Set the UI color scheme according to the options
-            if (App.Options.EnableDarkMode)
-                EnableDarkMode();
-            else
-                DisableDarkMode();
-
-            // Force the UI to reload after applying the theme
-            App.Instance.UpdateLayout();
-
             // Remove event handlers to ensure ordering
             if (removeEventHandlers)
                 DisableEventHandlers();
 
             // Refresh the drive info
-            Drive drive = App.Instance.DriveLetterComboBox.SelectedItem as Drive;
-            drive.RefreshDrive();
+            (App.Instance.DriveLetterComboBox.SelectedItem as Drive)?.RefreshDrive();
 
             // Set the initial environment and UI values
             Env = DetermineEnvironment();
-            GetOutputNames(true, true);
+            GetOutputNames(true);
             EnsureDiscInformation();
 
             // Enable event handlers
@@ -1012,7 +1002,7 @@ namespace MPF.UI.ViewModels
         /// Get the default output directory name from the currently selected drive
         /// </summary>
         /// <param name="driveChanged">Force an updated name if the drive letter changes</param>
-        public void GetOutputNames(bool driveChanged, bool forceUpdate = false)
+        public void GetOutputNames(bool driveChanged)
         {
             if (Drives == null || Drives.Count == 0 || App.Instance.DriveLetterComboBox.SelectedIndex == -1)
             {
@@ -1028,7 +1018,7 @@ namespace MPF.UI.ViewModels
             string extension = Env.Parameters?.GetDefaultExtension(mediaType);
 
             // Set the output filename, if it's not already
-            if (string.IsNullOrEmpty(App.Instance.OutputPathTextBox.Text) || forceUpdate)
+            if (string.IsNullOrEmpty(App.Instance.OutputPathTextBox.Text))
             {
                 string label = drive?.FormattedVolumeLabel ?? systemType.LongName();
                 string directory = App.Options.DefaultOutputPath;

--- a/MPF/ViewModels/MainViewModel.cs
+++ b/MPF/ViewModels/MainViewModel.cs
@@ -1532,7 +1532,10 @@ namespace MPF.UI.ViewModels
         private void UpdateVolumeLabelClick(object sender, RoutedEventArgs e)
         {
             if (_canExecuteSelectionChanged)
-                InitializeUIValues(removeEventHandlers: true, rescanDrives: false);
+            {
+                Env = DetermineEnvironment();
+                GetOutputNames(true);
+            }
         }
 
         #endregion

--- a/MPF/ViewModels/MainViewModel.cs
+++ b/MPF/ViewModels/MainViewModel.cs
@@ -432,7 +432,7 @@ namespace MPF.UI.ViewModels
             {
                 App.Instance.SystemTypeComboBox.IsEnabled = false;
                 App.Instance.MediaTypeComboBox.IsEnabled = false;
-                
+
                 App.Instance.OutputPathTextBox.IsEnabled = false;
                 App.Instance.OutputPathBrowseButton.IsEnabled = false;
 
@@ -449,7 +449,7 @@ namespace MPF.UI.ViewModels
 
                 App.Instance.SystemTypeComboBox.IsEnabled = true;
                 App.Instance.MediaTypeComboBox.IsEnabled = true;
-                
+
                 App.Instance.OutputPathTextBox.IsEnabled = true;
                 App.Instance.OutputPathBrowseButton.IsEnabled = true;
 
@@ -559,6 +559,23 @@ namespace MPF.UI.ViewModels
 
             // Set the initial environment and UI values
             SetSupportedDriveSpeed();
+            Env = DetermineEnvironment();
+            GetOutputNames(true);
+            EnsureDiscInformation();
+
+            // Enable event handlers
+            EnableEventHandlers();
+
+            // Enable the dumping button, if necessary
+            App.Instance.StartStopButton.IsEnabled = ShouldEnableDumpingButton();
+        }
+
+        /// <summary>
+        /// Performs a fast update of the output path while skipping disc checks
+        /// </summary>
+        private void FastUpdateLabel()
+        {
+            // Set the initial environment and UI values
             Env = DetermineEnvironment();
             GetOutputNames(true);
             EnsureDiscInformation();
@@ -1532,10 +1549,10 @@ namespace MPF.UI.ViewModels
         private void UpdateVolumeLabelClick(object sender, RoutedEventArgs e)
         {
             if (_canExecuteSelectionChanged)
-            {
-                Env = DetermineEnvironment();
-                GetOutputNames(true);
-            }
+                if (App.Options.FastUpdateLabel)
+                    FastUpdateLabel();
+                else
+                    InitializeUIValues(removeEventHandlers: true, rescanDrives: false);
         }
 
         #endregion

--- a/MPF/Windows/OptionsWindow.xaml
+++ b/MPF/Windows/OptionsWindow.xaml
@@ -70,11 +70,14 @@
                         <CheckBox VerticalAlignment="Center" Content="Enable Dark Mode"
                             IsChecked="{Binding Options.EnableDarkMode}"
                             ToolTip="(Experimental) Enable dark mode across the entire application" Margin="0,4"
-                            />
-
+                        />
                         <CheckBox VerticalAlignment="Center" Content="Check for Updates on Startup"
                                   IsChecked="{Binding Options.CheckForUpdatesOnStartup}"
                                   ToolTip="Check for updates when the application starts" Margin="0,4"
+                        />
+                        <CheckBox VerticalAlignment="Center" Content="Fast Update Label"
+                                  IsChecked="{Binding Options.FastUpdateLabel}"
+                                  ToolTip="Bypasses disc checks to quickly update the output path. Use with caution!" Margin="0,4"
                         />
                     </UniformGrid>
                 </TabItem>


### PR DESCRIPTION
Sets up the environment and simply updates the output path and filename. No System, Media, Drive, or Speed changes. It's a very fast update meant for large lots of similar discs.