### PR TITLE
Get error count from recent redumper log

### DIFF
--- a/MPF.Modules/Redumper/Parameters.cs
+++ b/MPF.Modules/Redumper/Parameters.cs
@@ -189,7 +189,7 @@ namespace MPF.Modules.Redumper
 
                     break;
             }
-            
+
             return (true, new List<string>());
         }
 
@@ -920,8 +920,11 @@ namespace MPF.Modules.Redumper
             {
                 try
                 {
+                    const string startMarker = "CD-ROM [";
+                    const string redumpMarker = "REDUMP.ORG errors";
+
                     // Fast forward to the errors lines
-                    while (!sr.EndOfStream && !sr.ReadLine().Trim().StartsWith("data errors"));
+                    while (!sr.EndOfStream && !sr.ReadLine().Trim().StartsWith(startMarker));
                     if (sr.EndOfStream)
                         return 0;
 
@@ -929,13 +932,13 @@ namespace MPF.Modules.Redumper
                     long errorCount = 0;
                     while (!sr.EndOfStream)
                     {
-                        // Skip forward to the "redump" line
+                        // Skip forward to the redump error line
                         string line;
-                        while (!(line = sr.ReadLine().Trim()).StartsWith("redump"));
+                        while (!(line = sr.ReadLine().Trim()).StartsWith(redumpMarker));
 
-                        // redump: <error count>
+                        // Get the number from the error line
                         string[] parts = line.Split(' ');
-                        if (long.TryParse(parts[1], out long redump))
+                        if (long.TryParse(parts.Last(), out long redump))
                             errorCount += redump;
                         else
                             return -1;
@@ -943,7 +946,7 @@ namespace MPF.Modules.Redumper
                         if (!sr.EndOfStream)
                             sr.ReadLine(); // Empty line
 
-                        if (!sr.EndOfStream && !sr.ReadLine().Trim().StartsWith("data errors"))
+                        if (!sr.EndOfStream && !sr.ReadLine().Trim().StartsWith(startMarker))
                             break;
                     }
 

--- a/MPF.Modules/Redumper/Parameters.cs
+++ b/MPF.Modules/Redumper/Parameters.cs
@@ -920,34 +920,12 @@ namespace MPF.Modules.Redumper
             {
                 try
                 {
-                    // Fast forward to the errors lines
-                    while (!sr.EndOfStream && !sr.ReadLine().Trim().StartsWith("data errors"));
+                    // REDUMP.ORG errors: <error count>
+                    string line = null;
+                    while (!sr.EndOfStream && !(line = sr.ReadLine().Trim()).StartsWith("REDUMP.ORG errors"));
                     if (sr.EndOfStream)
-                        return 0;
-
-                    // Now that we're at the relevant entries, read each line in and concatenate
-                    long errorCount = 0;
-                    while (!sr.EndOfStream)
-                    {
-                        // Skip forward to the "redump" line
-                        string line;
-                        while (!(line = sr.ReadLine().Trim()).StartsWith("redump"));
-
-                        // redump: <error count>
-                        string[] parts = line.Split(' ');
-                        if (long.TryParse(parts[1], out long redump))
-                            errorCount += redump;
-                        else
-                            return -1;
-
-                        if (!sr.EndOfStream)
-                            sr.ReadLine(); // Empty line
-
-                        if (!sr.EndOfStream && !sr.ReadLine().Trim().StartsWith("data errors"))
-                            break;
-                    }
-
-                    return errorCount;
+                        return -1;
+                    return long.TryParse(line.Split(' ').Last(), out long count) ? count : -1;
                 }
                 catch
                 {


### PR DESCRIPTION
I have simplified the process so it may not work correctly in the situation the original code envisioned.
It also does not process previous logs.

# Previous log
```
data errors [dump.bin]:
  ECC: 10
  EDC: 10
  redump: 10
```

# Recent log
```
*** MODE: info
CD-ROM [dump.bin]:
  sectors count: 271236
  mode1 sectors: 271236
  ECC errors: 65
  EDC errors: 65

  REDUMP.ORG errors: 65
```
