### PR TITLE
Get the write offset from the latest redumper

### DIFF
--- a/MPF.Modules/Redumper/Parameters.cs
+++ b/MPF.Modules/Redumper/Parameters.cs
@@ -1143,7 +1143,7 @@ namespace MPF.Modules.Redumper
                 try
                 {
                     // Fast forward to the offset lines
-                    while (!sr.EndOfStream && !sr.ReadLine().TrimStart().StartsWith("detecting offset"));
+                    while (!sr.EndOfStream && !sr.ReadLine().TrimStart().StartsWith("*** MODE: split"));
                     if (sr.EndOfStream)
                         return null;
 


### PR DESCRIPTION
`detecting offset` is gone from build 114.
This fix also works for previous redumper (up to build 113).
