### PR TITLE
Update hardware information pull from redumper

### DIFF
--- a/MPF.Modules/Redumper/Parameters.cs
+++ b/MPF.Modules/Redumper/Parameters.cs
@@ -1266,8 +1266,8 @@ namespace MPF.Modules.Redumper
             {
                 try
                 {
-                    // Fast forward to the dump line
-                    while (!(sr.ReadLine()?.Trim().StartsWith("*** MODE: dump") ?? true));
+                    // Fast forward to the drive information line
+                    while (!(sr.ReadLine()?.Trim().StartsWith("drive path:") ?? true));
 
                     // If we find the hardware info line, return each value
                     // drive: <vendor_id> - <product_id> (revision level: <product_revision_level>, vendor specific: <vendor_specific>)


### PR DESCRIPTION
Change the current fast-forward keyword as it has become unstable.
I checked with build 151 and 152.