### PR TITLE
Fix serial parsing from #542

### DIFF
--- a/MPF.Modules/BaseParameters.cs
+++ b/MPF.Modules/BaseParameters.cs
@@ -1857,7 +1857,7 @@ namespace MPF.Modules
                         {
                             case 'S':
                                 // Check first two digits of S_PS serial
-                                switch (serial.Substring(4, 2))
+                                switch (serial.Substring(5, 2))
                                 {
                                     case "46": return Region.SouthKorea;
                                     case "56": return Region.SouthKorea;
@@ -1867,7 +1867,7 @@ namespace MPF.Modules
                                 }
                             case 'M':
                                 // Check first three digits of S_PM serial
-                                switch (serial.Substring(4, 3))
+                                switch (serial.Substring(5, 3))
                                 {
                                     case "645": return Region.SouthKorea;
                                     case "675": return Region.SouthKorea;


### PR DESCRIPTION
I tested the changes from #542 and they don't work as intended, a "SLPM-645xx" disc is registered as "Japan"

I believe it is because the serial string being passed to this function has a "-" in it, i.e. serial = "SLPM-64511", whereas I had initially assumed it would be "SLPM64511".
Unfortunately I do not have the time to build MPF with this minor change to test this, so unless @mnadareski knows the string format of the serial being passed to this function, then this is the best I can do.

Otherwise, if it still doesn't work this function be simplified again to remove the serial-number parsing.