### PR TITLE
Remove IMAPI2 as a dependency

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,22 +3,11 @@
     "tasks": [
         {
             "label": "build",
-            "command": "msbuild",
+            "command": "dotnet",
             "type": "process",
             "args": [
+                "build",
                 "${workspaceFolder}/MPF.sln",
-                "-property:RuntimeIdentifiers=win7-x64"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "publish",
-            "command": "msbuild",
-            "type": "process",
-            "args": [
-                "${workspaceFolder}/MPF/MPF.csproj",
-                "-target:Publish",
-                "-property:RuntimeIdentifiers=win7-x64"
             ],
             "problemMatcher": "$msCompile"
         },

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -19,6 +19,7 @@
 - Remove msbuild-specific AppVeyor items
 - Be trickier when it comes to type from size
 - Fix "detected" message
+- Be smarter about media type based on system
 
 ### 2.6.6 (2023-10-04)
 

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -18,6 +18,7 @@
 - Update README with support information
 - Remove msbuild-specific AppVeyor items
 - Be trickier when it comes to type from size
+- Fix "detected" message
 
 ### 2.6.6 (2023-10-04)
 

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,4 +1,5 @@
 ### WIP (xxxx-xx-xx)
+
 - Attempt to replace NRT
 - Try alternate archive naming
 - Publish, but don't package, release builds

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -16,6 +16,7 @@
 - Slight reorganization of code
 - Update README with support information
 - Remove msbuild-specific AppVeyor items
+- Be trickier when it comes to type from size
 
 ### 2.6.6 (2023-10-04)
 

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -12,6 +12,7 @@
 - Add submission info preamble
 - Fix missing comma
 - Remove IMAPI2 with no substitution
+- Remove framework exceptions
 
 ### 2.6.6 (2023-10-04)
 

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -11,6 +11,7 @@
 - Don't reverse the CRC32 output
 - Add submission info preamble
 - Fix missing comma
+- Remove IMAPI2 with no substitution
 
 ### 2.6.6 (2023-10-04)
 

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -15,6 +15,7 @@
 - Remove framework exceptions
 - Slight reorganization of code
 - Update README with support information
+- Remove msbuild-specific AppVeyor items
 
 ### 2.6.6 (2023-10-04)
 

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -14,6 +14,7 @@
 - Remove IMAPI2 with no substitution
 - Remove framework exceptions
 - Slight reorganization of code
+- Update README with support information
 
 ### 2.6.6 (2023-10-04)
 

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -13,6 +13,7 @@
 - Fix missing comma
 - Remove IMAPI2 with no substitution
 - Remove framework exceptions
+- Slight reorganization of code
 
 ### 2.6.6 (2023-10-04)
 

--- a/MPF.Core/Converters/EnumConverter.cs
+++ b/MPF.Core/Converters/EnumConverter.cs
@@ -2,9 +2,6 @@
 using System.Collections.Concurrent;
 using System.IO;
 using System.Reflection;
-#if NETFRAMEWORK
-using IMAPI2;
-#endif
 using MPF.Core.Data;
 using SabreTools.RedumpLib.Data;
 
@@ -33,47 +30,6 @@ namespace MPF.Core.Converters
                     return null;
             }
         }
-
-#if NETFRAMEWORK
-        /// <summary>
-        /// Convert IMAPI physical media type to a MediaType
-        /// </summary>
-        /// <param name="type">IMAPI_MEDIA_PHYSICAL_TYPE value to check</param>
-        /// <returns>MediaType if possible, null on error</returns>
-        public static MediaType? IMAPIToMediaType(this IMAPI_MEDIA_PHYSICAL_TYPE type)
-        {
-            switch (type)
-            {
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_UNKNOWN:
-                    return MediaType.NONE;
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_CDROM:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_CDR:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_CDRW:
-                    return MediaType.CDROM;
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDROM:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDRAM:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDPLUSR:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDPLUSRW:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDPLUSR_DUALLAYER:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDDASHR:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDDASHRW:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDDASHR_DUALLAYER:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DISK:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDPLUSRW_DUALLAYER:
-                    return MediaType.DVD;
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_HDDVDROM:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_HDDVDR:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_HDDVDRAM:
-                    return MediaType.HDDVD;
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_BDROM:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_BDR:
-                case IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_BDRE:
-                    return MediaType.BluRay;
-                default:
-                    return null;
-            }
-        }
-#endif
 
         #endregion
 

--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -175,14 +175,18 @@ namespace MPF.Core.Data
         public (MediaType?, string) GetMediaType()
         {
             // Take care of the non-optical stuff first
-            if (this.InternalDriveType == Data.InternalDriveType.Floppy)
-                return (MediaType.FloppyDisk, null);
-            else if (this.InternalDriveType == Data.InternalDriveType.HardDisk)
-                return (MediaType.HardDisk, null);
-            else if (this.InternalDriveType == Data.InternalDriveType.Removable)
-                return (MediaType.FlashDrive, null);
-            else
-                return GetMediaTypeFromSize();
+            switch (this.InternalDriveType)
+            {
+                case Data.InternalDriveType.Floppy:
+                    return (MediaType.FloppyDisk, null);
+                case Data.InternalDriveType.HardDisk:
+                    return (MediaType.HardDisk, null);
+                case Data.InternalDriveType.Removable:
+                    return (MediaType.FlashDrive, null);
+            }
+
+            // Handle optical media
+            return GetMediaTypeFromSize();
         }
 
         /// <summary>

--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -516,10 +516,16 @@ namespace MPF.Core.Data
         {
             if (this.TotalSize >= 0 && this.TotalSize < 800_000_000 && this.DriveFormat == "CDFS")
                 return (MediaType.CDROM, null);
+            else if (this.TotalSize >= 0 && this.TotalSize < 400_000_000 && this.DriveFormat == "UDF")
+                return (MediaType.CDROM, null);
+            else if (this.TotalSize >= 800_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "CDFS")
+                return (MediaType.DVD, null);
             else if (this.TotalSize >= 400_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "UDF")
                 return (MediaType.DVD, null);
-            else
+            else if (this.TotalSize > 8_540_000_000)
                 return (MediaType.BluRay, null);
+
+            return (null, "Size and filesystem combination could not help determine media type!");
         }
 
         /// <summary>

--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -171,8 +171,9 @@ namespace MPF.Core.Data
         /// <summary>
         /// Get the current media type from drive letter
         /// </summary>
+        /// <param name="system"></param>
         /// <returns></returns>
-        public (MediaType?, string) GetMediaType()
+        public (MediaType?, string) GetMediaType(RedumpSystem? system)
         {
             // Take care of the non-optical stuff first
             switch (this.InternalDriveType)
@@ -185,8 +186,68 @@ namespace MPF.Core.Data
                     return (MediaType.FlashDrive, null);
             }
 
-            // Handle optical media
-            return GetMediaTypeFromSize();
+            // Some systems should default to certain media types
+            switch (system)
+            {
+                // CD
+                case RedumpSystem.Panasonic3DOInteractiveMultiplayer:
+                case RedumpSystem.PhilipsCDi:
+                case RedumpSystem.SegaDreamcast:
+                case RedumpSystem.SegaSaturn:
+                case RedumpSystem.SonyPlayStation:
+                case RedumpSystem.VideoCD:
+                    return (MediaType.CDROM, null);
+
+                // DVD
+                case RedumpSystem.DVDAudio:
+                case RedumpSystem.DVDVideo:
+                case RedumpSystem.MicrosoftXbox:
+                case RedumpSystem.MicrosoftXbox360:
+                    return (MediaType.DVD, null);
+
+                // HD-DVD
+                case RedumpSystem.HDDVDVideo:
+                    return (MediaType.HDDVD, null);
+
+                // Blu-ray
+                case RedumpSystem.BDVideo:
+                case RedumpSystem.MicrosoftXboxOne:
+                case RedumpSystem.MicrosoftXboxSeriesXS:
+                case RedumpSystem.SonyPlayStation3:
+                case RedumpSystem.SonyPlayStation4:
+                case RedumpSystem.SonyPlayStation5:
+                    return (MediaType.BluRay, null);
+
+                // GameCube
+                case RedumpSystem.NintendoGameCube:
+                    return (MediaType.NintendoGameCubeGameDisc, null);
+
+                // Wii
+                case RedumpSystem.NintendoWii:
+                    return (MediaType.NintendoWiiOpticalDisc, null);
+
+                // WiiU
+                case RedumpSystem.NintendoWiiU:
+                    return (MediaType.NintendoWiiUOpticalDisc, null);
+
+                // PSP
+                case RedumpSystem.SonyPlayStationPortable:
+                    return (MediaType.UMD, null);
+            }
+
+            // Handle optical media by size and filesystem
+            if (this.TotalSize >= 0 && this.TotalSize < 800_000_000 && this.DriveFormat == "CDFS")
+                return (MediaType.CDROM, null);
+            else if (this.TotalSize >= 0 && this.TotalSize < 400_000_000 && this.DriveFormat == "UDF")
+                return (MediaType.CDROM, null);
+            else if (this.TotalSize >= 800_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "CDFS")
+                return (MediaType.DVD, null);
+            else if (this.TotalSize >= 400_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "UDF")
+                return (MediaType.DVD, null);
+            else if (this.TotalSize > 8_540_000_000)
+                return (MediaType.BluRay, null);
+
+            return (null, "Could not determine media type!");
         }
 
         /// <summary>
@@ -507,26 +568,6 @@ namespace MPF.Core.Data
         #endregion
 
         #region Helpers
-
-        /// <summary>
-        /// Get the media type for a device path based on size
-        /// </summary>
-        /// <returns>MediaType, null on error</returns>
-        private (MediaType?, string) GetMediaTypeFromSize()
-        {
-            if (this.TotalSize >= 0 && this.TotalSize < 800_000_000 && this.DriveFormat == "CDFS")
-                return (MediaType.CDROM, null);
-            else if (this.TotalSize >= 0 && this.TotalSize < 400_000_000 && this.DriveFormat == "UDF")
-                return (MediaType.CDROM, null);
-            else if (this.TotalSize >= 800_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "CDFS")
-                return (MediaType.DVD, null);
-            else if (this.TotalSize >= 400_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "UDF")
-                return (MediaType.DVD, null);
-            else if (this.TotalSize > 8_540_000_000)
-                return (MediaType.BluRay, null);
-
-            return (null, "Size and filesystem combination could not help determine media type!");
-        }
 
         /// <summary>
         /// Get all current attached Drives

--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -175,7 +175,6 @@ namespace MPF.Core.Data
         public (MediaType?, string) GetMediaType()
         {
             // Take care of the non-optical stuff first
-            // TODO: See if any of these can be more granular, like Optical is
             if (this.InternalDriveType == Data.InternalDriveType.Floppy)
                 return (MediaType.FloppyDisk, null);
             else if (this.InternalDriveType == Data.InternalDriveType.HardDisk)

--- a/MPF.Core/MPF.Core.csproj
+++ b/MPF.Core/MPF.Core.csproj
@@ -9,27 +9,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net48'">
-    <COMReference Include="IMAPI2">
-      <Guid>{2735412F-7F64-5B0F-8F00-5D77AFBE261E}</Guid>
-      <VersionMajor>1</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="IMAPI2FS">
-      <Guid>{2C941FD0-975B-59BE-A960-9A2A262853A5}</Guid>
-      <VersionMajor>1</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0-preview.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/MPF.Test/Core/Converters/EnumConverterTests.cs
+++ b/MPF.Test/Core/Converters/EnumConverterTests.cs
@@ -2,9 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-#if NETFRAMEWORK
-using IMAPI2;
-#endif
 using MPF.Core.Converters;
 using MPF.Core.Data;
 using Xunit;
@@ -25,35 +22,6 @@ namespace MPF.Test.Core.Converters
             DriveType.Removable,
         };
 
-#if NETFRAMEWORK
-        /// <summary>
-        /// IMAPI_MEDIA_PHYSICAL_TYPE values that map to MediaType
-        /// </summary>
-        private static readonly IMAPI_MEDIA_PHYSICAL_TYPE[] _mappableImapiTypes = new IMAPI_MEDIA_PHYSICAL_TYPE[]
-        {
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_UNKNOWN,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_CDROM,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_CDR,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_CDRW,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDROM,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDRAM,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDPLUSR,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDPLUSRW,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDPLUSR_DUALLAYER,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDDASHR,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDDASHRW,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDDASHR_DUALLAYER,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DISK,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_DVDPLUSRW_DUALLAYER,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_HDDVDROM,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_HDDVDR,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_HDDVDRAM,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_BDROM,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_BDR,
-            IMAPI_MEDIA_PHYSICAL_TYPE.IMAPI_MEDIA_TYPE_BDRE,
-        };
-#endif
-
         /// <summary>
         /// Check that every supported DriveType maps to an InternalDriveType
         /// </summary>
@@ -70,25 +38,6 @@ namespace MPF.Test.Core.Converters
             else
                 Assert.NotNull(actual);
         }
-
-#if NETFRAMEWORK
-        /// <summary>
-        /// Check that every supported IMAPI_MEDIA_PHYSICAL_TYPE maps to an MediaType
-        /// </summary>
-        /// <param name="imapiType">IMAPI_MEDIA_PHYSICAL_TYPE value to check</param>
-        /// <param name="expectNull">True to expect a null mapping, false otherwise</param>
-        [Theory]
-        [MemberData(nameof(GenerateImapiTypeMappingTestData))]
-        public void IMAPIToMediaTypeTest(IMAPI_MEDIA_PHYSICAL_TYPE imapiType, bool expectNull)
-        {
-            var actual = imapiType.IMAPIToMediaType();
-
-            if (expectNull)
-                Assert.Null(actual);
-            else
-                Assert.NotNull(actual);
-        }
-#endif
 
         /// <summary>
         /// Generate a test set of DriveType values
@@ -107,26 +56,6 @@ namespace MPF.Test.Core.Converters
 
             return testData;
         }
-
-#if NETFRAMEWORK
-        /// <summary>
-        /// Generate a test set of IMAPI_MEDIA_PHYSICAL_TYPE values
-        /// </summary>
-        /// <returns>MemberData-compatible list of IMAPI_MEDIA_PHYSICAL_TYPE values</returns>
-        public static List<object[]> GenerateImapiTypeMappingTestData()
-        {
-            var testData = new List<object[]>() { new object[] { null, false } };
-            foreach (IMAPI_MEDIA_PHYSICAL_TYPE imapiType in Enum.GetValues(typeof(IMAPI_MEDIA_PHYSICAL_TYPE)))
-            {
-                if (_mappableImapiTypes.Contains(imapiType))
-                    testData.Add(new object[] { imapiType, false });
-                else
-                    testData.Add(new object[] { imapiType, true });
-            }
-
-            return testData;
-        }
-#endif
 
         #endregion
 

--- a/MPF.Test/MPF.Test.csproj
+++ b/MPF.Test/MPF.Test.csproj
@@ -5,27 +5,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net48'">
-    <COMReference Include="IMAPI2">
-      <Guid>{2735412F-7F64-5B0F-8F00-5D77AFBE261E}</Guid>
-      <VersionMajor>1</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="IMAPI2FS">
-      <Guid>{2C941FD0-975B-59BE-A960-9A2A262853A5}</Guid>
-      <VersionMajor>1</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\MPF\MPF.csproj" />
     <ProjectReference Include="..\MPF.Library\MPF.Library.csproj" />

--- a/MPF.UI.Core/ViewModels/MainViewModel.cs
+++ b/MPF.UI.Core/ViewModels/MainViewModel.cs
@@ -877,7 +877,7 @@ namespace MPF.UI.Core.ViewModels
             {
                 if (this.Options.VerboseLogging)
                     this.Logger.VerboseLog($"Trying to detect media type for drive {drive.Letter} [{drive.DriveFormat}] using size and filesystem.. ");
-                (MediaType? detectedMediaType, string errorMessage) = drive.GetMediaType();
+                (MediaType? detectedMediaType, string errorMessage) = drive.GetMediaType(currentSystem);
 
                 // If we got an error message, post it to the log
                 if (errorMessage != null && this.Options.VerboseLogging)

--- a/MPF.UI.Core/ViewModels/MainViewModel.cs
+++ b/MPF.UI.Core/ViewModels/MainViewModel.cs
@@ -865,7 +865,6 @@ namespace MPF.UI.Core.ViewModels
             if (defaultMediaType == MediaType.NONE)
                 defaultMediaType = MediaType.CDROM;
 
-#if NET48 || NETSTANDARD2_1
             // If we're skipping detection, set the default value
             if (this.Options.SkipMediaTypeDetection)
             {
@@ -877,7 +876,7 @@ namespace MPF.UI.Core.ViewModels
             else if (drive.MarkedActive)
             {
                 if (this.Options.VerboseLogging)
-                    this.Logger.VerboseLog($"Trying to detect media type for drive {drive.Letter} [{drive.DriveFormat}].. ");
+                    this.Logger.VerboseLog($"Trying to detect media type for drive {drive.Letter} [{drive.DriveFormat}] using size and filesystem.. ");
                 (MediaType? detectedMediaType, string errorMessage) = drive.GetMediaType();
 
                 // If we got an error message, post it to the log
@@ -906,12 +905,6 @@ namespace MPF.UI.Core.ViewModels
                     this.Logger.VerboseLogLn($"Drive marked as empty, defaulting to {defaultMediaType.LongName()}.");
                 CurrentMediaType = defaultMediaType;
             }
-#else
-            // Media type detection on initialize is always disabled
-            if (this.Options.VerboseLogging)
-                this.Logger.VerboseLogLn($"Media type detection not available, defaulting to {defaultMediaType.LongName()}.");
-            CurrentMediaType = defaultMediaType;
-#endif
 
             // Ensure the UI gets updated
             this.Parent.UpdateLayout();

--- a/MPF.UI.Core/ViewModels/MainViewModel.cs
+++ b/MPF.UI.Core/ViewModels/MainViewModel.cs
@@ -893,7 +893,7 @@ namespace MPF.UI.Core.ViewModels
                 else
                 {
                     if (this.Options.VerboseLogging)
-                        this.Logger.VerboseLogLn($"Detected {CurrentMediaType.LongName()}.");
+                        this.Logger.VerboseLogLn($"Detected {detectedMediaType.LongName()}.");
                     CurrentMediaType = detectedMediaType;
                 }
             }

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml.cs
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml.cs
@@ -20,12 +20,6 @@ namespace MPF.UI.Core.Windows
         {
             InitializeComponent();
             DataContext = new OptionsViewModel(this, options);
-
-#if NET6_0_OR_GREATER
-            this.SkipMediaTypeDetectionCheckBox.IsEnabled = false;
-            this.SkipMediaTypeDetectionCheckBox.IsChecked = false;
-            this.SkipMediaTypeDetectionCheckBox.ToolTip = "This feature is not enabled for .NET 6";
-#endif
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -34,28 +34,19 @@ Ensure that your operating system is as up-to-date as possible, since some featu
 
 ### Support Limitations
 
-.NET 6 has some known limitations that are documented in code and in some prior support tickets:
+The main UI has some known limitations that are documented in code and in some prior support tickets:
 
 - Windows-only due to reliance on WPF and Winforms
     - MAUI is not a viable alternative due to lack of out-of-box support for Linux
-    - Avalonia is being heavily considered
-- No media type detection due to lack of alternatives to IMAPI2
+    - Avalonia is being heavily considered as an alternative
 
 ### Build Instructions
 
-To build for .NET Framework 4.8 (Windows only), ensure that the .NET Framework 4.8 SDK is installed and included in your PATH. Then, run the following commands from command prompt, Powershell, or Terminal:
+To build for .NET Framework 4.8, .NET 6.0, or .NET 7.0 (all Windows only), ensure that the .NET 7.0 SDK (or later) is installed and included in your PATH. Then, run the following commands from command prompt, Powershell, or Terminal:
 
 ```
-dotnet restore
-msbuild MPF\MPF.csproj -property:TargetFramework=net48 -property:RuntimeIdentifiers=win7-x64
+dotnet build MPF\MPF.csproj --framework [net48|net6.0-windows|net7.0-windows] --runtime [win-x64]
 ```
-
-To build for .NET 6.0 or .NET 7.0 (Windows only), ensure that the .NET 7.0 SDK (or later) is installed and included in your PATH. Then, run the following commands from command prompt, Powershell, or Terminal:
-
-```
-dotnet build MPF\MPF.csproj --framework net6.0-windows --runtime [win-x64]
-```
-
 
 ## Media Preservation Frontend Checker (MPF.Check)
 
@@ -68,17 +59,10 @@ MPF.Check is a commandline-only program that allows users to generate submission
 
 ### Build Instructions
 
-To build for .NET Framework 4.8 (Windows only), ensure that the .NET Framework 4.8 SDK is installed and included in your PATH. Then, run the following commands from command prompt, Powershell, or Terminal:
+To build for .NET Framework 4.8 (Windows only), .NET 6.0, and .NET 7.0 (both all supported OSes), ensure that the .NET 7.0 SDK (or later) is installed and included in your PATH. Then, run the following commands from command prompt, Powershell, Terminal, or shell:
 
 ```
-dotnet restore
-msbuild MPF.Check\MPF.Check.csproj -property:TargetFramework=net48 -property:RuntimeIdentifiers=win7-x64
-```
-
-To build for .NET 6.0 and .NET 7.0 (All supported OSes), ensure that the .NET 7.0 SDK (or later) is installed and included in your PATH. Then, run the following commands from command prompt, Powershell, Terminal, or shell:
-
-```
-dotnet build MPF.Check\MPF.Check.csproj --framework net6.0 --runtime [win-x64linux-x64|osx-x64]
+dotnet build MPF.Check\MPF.Check.csproj --framework [net48|net6.0|net7.0] --runtime [win-x64linux-x64|osx-x64]
 ```
 
 Choose one of `[win-x64|linux-x64|osx-x64]` depending on the machine you are targeting.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,18 +8,6 @@ pull_requests:
 # vm template
 image: Visual Studio 2022
 
-# environment variables
-environment:
-  EnableNuGetPackageRestore: true
-
-# install dependencies
-install:
-- ps: appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-
-# pre-build script
-before_build:
-- nuget restore
-
 # build step
 build_script:
   - dotnet restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,12 +25,12 @@ build_script:
   - dotnet restore
 
   # .NET Framework 4.8 Debug
-  - msbuild MPF\MPF.csproj -target:Publish -property:TargetFramework=net48 -property:RuntimeIdentifiers=win7-x64 -property:VersionSuffix=%APPVEYOR_REPO_COMMIT%
-  - msbuild MPF.Check\MPF.Check.csproj -target:Publish -property:TargetFramework=net48 -property:RuntimeIdentifiers=win7-x64 -property:VersionSuffix=%APPVEYOR_REPO_COMMIT%
+  - dotnet publish MPF\MPF.csproj -f net48 -r win7-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT%
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net48 -r win7-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT%
 
   # .NET Framework 4.8 Release
-  - msbuild MPF\MPF.csproj -target:Publish -property:TargetFramework=net48 -property:Configuration=Release -property:RuntimeIdentifiers=win7-x64 -property:VersionSuffix=%APPVEYOR_REPO_COMMIT%
-  - msbuild MPF.Check\MPF.Check.csproj -target:Publish -property:TargetFramework=net48 -property:Configuration=Release -property:RuntimeIdentifiers=win7-x64 -property:VersionSuffix=%APPVEYOR_REPO_COMMIT%
+  - dotnet publish MPF\MPF.csproj -f net48 -c Release -r win7-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT%
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net48 -c Release -r win7-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT%
 
   # .NET 6.0 Debug
   - dotnet publish MPF\MPF.csproj -f net6.0-windows -r win-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
@@ -61,33 +61,33 @@ after_build:
 
 # Aaru
 - ps: appveyor DownloadFile https://github.com/aaru-dps/Aaru/releases/download/v5.3.2/aaru-5.3.2_windows_x64.zip
-- 7z x aaru-5.3.2_windows_x64.zip -oMPF\bin\Debug\net48\publish\Programs\Aaru *
+- 7z x aaru-5.3.2_windows_x64.zip -oMPF\bin\Debug\net48\win7-x64\publish\Programs\Aaru *
 - 7z x aaru-5.3.2_windows_x64.zip -oMPF\bin\Debug\net6.0-windows\win-x64\publish\Programs\Aaru *
 - 7z x aaru-5.3.2_windows_x64.zip -oMPF\bin\Debug\net7.0-windows\win-x64\publish\Programs\Aaru *
-# - 7z x aaru-5.3.2_windows_x64.zip -oMPF\bin\Release\net48\publish\Programs\Aaru *
+# - 7z x aaru-5.3.2_windows_x64.zip -oMPF\bin\Release\net48\win7-x64\publish\Programs\Aaru *
 # - 7z x aaru-5.3.2_windows_x64.zip -oMPF\bin\Release\net6.0-windows\win-x64\publish\Programs\Aaru *
 # - 7z x aaru-5.3.2_windows_x64.zip -oMPF\bin\Release\net7.0-windows\win-x64\publish\Programs\Aaru *
 
 # DiscImageCreator
 - ps: appveyor DownloadFile https://github.com/saramibreak/DiscImageCreator/files/11660558/DiscImageCreator_20230606.zip
-- 7z e DiscImageCreator_20230606.zip -oMPF\bin\Debug\net48\publish\Programs\Creator Release_ANSI\*
+- 7z e DiscImageCreator_20230606.zip -oMPF\bin\Debug\net48\win7-x64\publish\Programs\Creator Release_ANSI\*
 - 7z e DiscImageCreator_20230606.zip -oMPF\bin\Debug\net6.0-windows\win-x64\publish\Programs\Creator Release_ANSI\*
 - 7z e DiscImageCreator_20230606.zip -oMPF\bin\Debug\net7.0-windows\win-x64\publish\Programs\Creator Release_ANSI\*
-# - 7z e DiscImageCreator_20230606.zip -oMPF\bin\Release\net48\publish\Programs\Creator Release_ANSI\*
+# - 7z e DiscImageCreator_20230606.zip -oMPF\bin\Release\net48\win7-x64\publish\Programs\Creator Release_ANSI\*
 # - 7z e DiscImageCreator_20230606.zip -oMPF\bin\Release\net6.0-windows\win-x64\publish\Programs\Creator Release_ANSI\*
 # - 7z e DiscImageCreator_20230606.zip -oMPF\bin\Release\net7.0-windows\win-x64\publish\Programs\Creator Release_ANSI\*
 
 # Redumper
 - ps: appveyor DownloadFile https://github.com/superg/redumper/releases/download/build_221/redumper-2023.10.02_build221-win64.zip
-- 7z e redumper-2023.10.02_build221-win64.zip -oMPF\bin\Debug\net48\publish\Programs\Redumper redumper-2023.10.02_build221-win64\bin\*
+- 7z e redumper-2023.10.02_build221-win64.zip -oMPF\bin\Debug\net48\win7-x64\publish\Programs\Redumper redumper-2023.10.02_build221-win64\bin\*
 - 7z e redumper-2023.10.02_build221-win64.zip -oMPF\bin\Debug\net6.0-windows\win-x64\publish\Programs\Redumper redumper-2023.10.02_build221-win64\bin\*
 - 7z e redumper-2023.10.02_build221-win64.zip -oMPF\bin\Debug\net7.0-windows\win-x64\publish\Programs\Redumper redumper-2023.10.02_build221-win64\bin\*
-# - 7z e redumper-2023.10.02_build221-win64.zip -oMPF\bin\Release\net48\publish\Programs\Redumper redumper-2023.10.02_build221-win64\bin\*
+# - 7z e redumper-2023.10.02_build221-win64.zip -oMPF\bin\Release\net48\win7-x64\publish\Programs\Redumper redumper-2023.10.02_build221-win64\bin\*
 # - 7z e redumper-2023.10.02_build221-win64.zip -oMPF\bin\Release\net6.0-windows\win-x64\publish\Programs\Redumper redumper-2023.10.02_build221-win64\bin\*
 # - 7z e redumper-2023.10.02_build221-win64.zip -oMPF\bin\Release\net7.0-windows\win-x64\publish\Programs\Redumper redumper-2023.10.02_build221-win64\bin\*
 
 # Create MPF Debug archives
-- cd %APPVEYOR_BUILD_FOLDER%\MPF\bin\Debug\net48\publish\
+- cd %APPVEYOR_BUILD_FOLDER%\MPF\bin\Debug\net48\win7-x64\publish\
 - 7z a -tzip %APPVEYOR_BUILD_FOLDER%\MPF_%APPVEYOR_BUILD_NUMBER%_net48_debug.zip *
 - cd %APPVEYOR_BUILD_FOLDER%\MPF\bin\Debug\net6.0-windows\win-x64\publish\
 - 7z a -tzip %APPVEYOR_BUILD_FOLDER%\MPF_%APPVEYOR_BUILD_NUMBER%_net6.0_win-x64_debug.zip *
@@ -95,7 +95,7 @@ after_build:
 - 7z a -tzip %APPVEYOR_BUILD_FOLDER%\MPF_%APPVEYOR_BUILD_NUMBER%_net7.0_win-x64_debug.zip *
 
 # # Create MPF Release archives
-# - cd %APPVEYOR_BUILD_FOLDER%\MPF\bin\Release\net48\publish\
+# - cd %APPVEYOR_BUILD_FOLDER%\MPF\bin\Release\net48\win7-x64\publish\
 # - 7z a -tzip %APPVEYOR_BUILD_FOLDER%\MPF_%APPVEYOR_BUILD_NUMBER%_net48_release.zip *
 # - cd %APPVEYOR_BUILD_FOLDER%\MPF\bin\Release\net6.0-windows\win-x64\publish\
 # - 7z a -tzip %APPVEYOR_BUILD_FOLDER%\MPF_%APPVEYOR_BUILD_NUMBER%_net6.0_win-x64_release.zip *
@@ -103,7 +103,7 @@ after_build:
 # - 7z a -tzip %APPVEYOR_BUILD_FOLDER%\MPF_%APPVEYOR_BUILD_NUMBER%_net7.0_win-x64_release.zip *
 
 # Create MPF.Check Debug archives
-- cd %APPVEYOR_BUILD_FOLDER%\MPF.Check\bin\Debug\net48\publish\
+- cd %APPVEYOR_BUILD_FOLDER%\MPF.Check\bin\Debug\net48\win7-x64\publish\
 - 7z a -tzip %APPVEYOR_BUILD_FOLDER%\MPF.Check_%APPVEYOR_BUILD_NUMBER%_net48_debug.zip *
 - cd %APPVEYOR_BUILD_FOLDER%\MPF.Check\bin\Debug\net6.0\win-x64\publish\
 - 7z a -tzip %APPVEYOR_BUILD_FOLDER%\MPF.Check_%APPVEYOR_BUILD_NUMBER%_net6.0_win-x64_debug.zip *
@@ -119,7 +119,7 @@ after_build:
 - 7z a -tzip %APPVEYOR_BUILD_FOLDER%\MPF.Check_%APPVEYOR_BUILD_NUMBER%_net7.0_osx-x64_debug.zip *
 
 # # Create MPF.Check Release archives
-# - cd %APPVEYOR_BUILD_FOLDER%\MPF.Check\bin\Release\net48\publish\
+# - cd %APPVEYOR_BUILD_FOLDER%\MPF.Check\bin\Release\net48\win7-x64\publish\
 # - 7z a -tzip %APPVEYOR_BUILD_FOLDER%\MPF.Check_%APPVEYOR_BUILD_NUMBER%_net48_release.zip *
 # - cd %APPVEYOR_BUILD_FOLDER%\MPF.Check\bin\Release\net6.0\win-x64\publish\
 # - 7z a -tzip %APPVEYOR_BUILD_FOLDER%\MPF.Check_%APPVEYOR_BUILD_NUMBER%_net6.0_win-x64_release.zip *

--- a/publish-win.bat
+++ b/publish-win.bat
@@ -23,13 +23,13 @@ dotnet restore
 
 REM .NET Framework 4.8 Debug
 echo Building .NET Framework 4.8 debug
-msbuild MPF\MPF.csproj -target:Publish -property:TargetFramework=net48 -property:RuntimeIdentifiers=win7-x64 -property:VersionSuffix=%COMMIT%
-msbuild MPF.Check\MPF.Check.csproj -target:Publish -property:TargetFramework=net48 -property:RuntimeIdentifiers=win7-x64 -property:VersionSuffix=%COMMIT%
+dotnet publish MPF\MPF.csproj -f net48 -r win7-x64 --self-contained true --version-suffix %COMMIT%
+dotnet publish MPF.Check\MPF.Check.csproj -f net48 -r win7-x64 --self-contained true --version-suffix %COMMIT%
 
 REM .NET Framework 4.8 Release
 echo Building .NET Framework 4.8 release
-msbuild MPF\MPF.csproj -target:Publish -property:TargetFramework=net48 -property:Configuration=Release -property:RuntimeIdentifiers=win7-x64 -property:VersionSuffix=%COMMIT%
-msbuild MPF.Check\MPF.Check.csproj -target:Publish -property:TargetFramework=net48  -property:Configuration=Release -property:RuntimeIdentifiers=win7-x64 -property:VersionSuffix=%COMMIT%
+dotnet publish MPF\MPF.csproj -f net48 -c Release -r win7-x64 --self-contained true --version-suffix %COMMIT%
+dotnet publish MPF.Check\MPF.Check.csproj -f net48 -c Release -r win7-x64 --self-contained true --version-suffix %COMMIT%
 
 REM .NET 6.0 Debug
 echo Building .NET 6.0 debug
@@ -60,7 +60,7 @@ dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r linux-x64 -c Release --se
 dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r osx-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
 
 REM Create MPF Debug archives
-cd %BUILD_FOLDER%\MPF\bin\Debug\net48\publish\
+cd %BUILD_FOLDER%\MPF\bin\Debug\net48\win7-x64\publish\
 7z a -tzip %BUILD_FOLDER%\MPF_net48_debug.zip *
 cd %BUILD_FOLDER%\MPF\bin\Debug\net6.0-windows\win-x64\publish\
 7z a -tzip %BUILD_FOLDER%\MPF_net6.0_win-x64_debug.zip *
@@ -68,7 +68,7 @@ cd %BUILD_FOLDER%\MPF\bin\Debug\net7.0-windows\win-x64\publish\
 7z a -tzip %BUILD_FOLDER%\MPF_net7.0_win-x64_debug.zip *
 
 REM Create MPF Release archives
-cd %BUILD_FOLDER%\MPF\bin\Release\net48\publish\
+cd %BUILD_FOLDER%\MPF\bin\Release\net48\win7-x64\publish\
 7z a -tzip %BUILD_FOLDER%\MPF_net48_release.zip *
 cd %BUILD_FOLDER%\MPF\bin\Release\net6.0-windows\win-x64\publish\
 7z a -tzip %BUILD_FOLDER%\MPF_net6.0_win-x64_release.zip *
@@ -76,7 +76,7 @@ cd %BUILD_FOLDER%\MPF\bin\Release\net7.0-windows\win-x64\publish\
 7z a -tzip %BUILD_FOLDER%\MPF_net7.0_win-x64_release.zip *
 
 REM Create MPF.Check Debug archives
-cd %BUILD_FOLDER%\MPF.Check\bin\Debug\net48\publish\
+cd %BUILD_FOLDER%\MPF.Check\bin\Debug\net48\win7-x64\publish\
 7z a -tzip %BUILD_FOLDER%\MPF.Check_net48_debug.zip *
 cd %BUILD_FOLDER%\MPF.Check\bin\Debug\net6.0\win-x64\publish\
 7z a -tzip %BUILD_FOLDER%\MPF.Check_net6.0_win-x64_debug.zip *
@@ -92,7 +92,7 @@ cd %BUILD_FOLDER%\MPF.Check\bin\Debug\net7.0\osx-x64\publish\
 7z a -tzip %BUILD_FOLDER%\MPF.Check_net7.0_osx-x64_debug.zip *
 
 REM Create MPF.Check Release archives
-cd %BUILD_FOLDER%\MPF.Check\bin\Release\net48\publish\
+cd %BUILD_FOLDER%\MPF.Check\bin\Release\net48\win7-x64\publish\
 7z a -tzip %BUILD_FOLDER%\MPF.Check_net48_release.zip *
 cd %BUILD_FOLDER%\MPF.Check\bin\Release\net6.0\win-x64\publish\
 7z a -tzip %BUILD_FOLDER%\MPF.Check_net6.0_win-x64_release.zip *


### PR DESCRIPTION
## Problem

IMAPI2 is a Windows library that allows for media type detection and media burning in Windows applications. It is lightly maintained but is entirely locked to the Windows platform. IMAPI2 is a major blocker to making the entirety of MPF cross-platform, with the other major blocker being the UI framework. Removing this library would mean the end of very accurate media type detection.

## Solution

Remove IMAPI2 from the application even if it means less accurate media type detection until another solution is found. This solution allows .NET Framework 4.8 builds to be built and packaged near-identically to the newer .NET 6 and .NET 7 builds and places those more modern .NET builds on equal footing.

## Commentary

This is deliberately being made into a separate branch because this is a very divisive change. This removes the ability (on .NET Framework 4.8) to accurately determine the type of the media being detected, instead falling back on the same method that .NET 6 and .NET 7 use. This fallback method makes a best guess based on the media size and the filesystem.

The only dumping program supported by MPF right now that cares about the media type on dump is DiscImageCreator. It is still the default program and is the only one that benefits from this arrangement. If this is removed, there's more of a burden on the user to determine what type the media is before dumping.

This does put all 3 build versions (.NET Framework 4.8, .NET 6.0, and .NET 7.0) on equal footing for the first time, however. The build instructions become the same and no differences in functionality will be observed. For .NET Framework 4.8, this may also bring slightly more stability, given that IMAPI2 does not play well with all hardware.

## Alternatives

- Keeping IMAPI2 means that it can only be used on Windows ever in the future. It also is not actively maintained
- Using Aaru code is possible, but a very large chunk of code would need to be imported and potentially modified to work with .NET Framework 4.8 (a separate issue unto itself)
- Porting code from Redumper or another cross-platform tool is a possibility, but is not in the immediate cards for prioritized work
- Using the size/filesystem method is quick and semi-reasonably accurate but can be turned off exactly like the existing solutions