### PR TITLE
Remove debug symbols in release builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,36 +13,36 @@ build_script:
   - dotnet restore
 
   # .NET Framework 4.8 Debug
-  - dotnet publish MPF\MPF.csproj -f net48 -r win7-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT%
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net48 -r win7-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT%
+  - dotnet publish MPF\MPF.csproj -f net48 -r win7-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT%
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net48 -r win7-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT%
 
   # .NET Framework 4.8 Release
-  - dotnet publish MPF\MPF.csproj -f net48 -c Release -r win7-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT%
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net48 -c Release -r win7-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT%
+  - dotnet publish MPF\MPF.csproj -f net48 -r win7-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:DebugType=None -p:DebugSymbols=false
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net48 -r win7-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:DebugType=None -p:DebugSymbols=false
 
   # .NET 6.0 Debug
-  - dotnet publish MPF\MPF.csproj -f net6.0-windows -r win-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r win-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r linux-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r osx-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
+  - dotnet publish MPF\MPF.csproj -f net6.0-windows -r win-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r win-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r linux-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r osx-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
 
   # .NET 6.0 Release
-  - dotnet publish MPF\MPF.csproj -f net6.0-windows -r win-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r win-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r linux-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r osx-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
+  - dotnet publish MPF\MPF.csproj -f net6.0-windows -r win-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r win-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r linux-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r osx-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
 
   # .NET 7.0 Debug
-  - dotnet publish MPF\MPF.csproj -f net7.0-windows -r win-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r win-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
+  - dotnet publish MPF\MPF.csproj -f net7.0-windows -r win-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r win-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
   - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r linux-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r osx-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r osx-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
 
   # .NET 7.0 Release
-  - dotnet publish MPF\MPF.csproj -f net7.0-windows -r win-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r win-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r linux-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r osx-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
+  - dotnet publish MPF\MPF.csproj -f net7.0-windows -r win-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r win-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r linux-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r osx-x64 -c Release --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
 
 # post-build step
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ build_script:
   # .NET 7.0 Debug
   - dotnet publish MPF\MPF.csproj -f net7.0-windows -r win-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
   - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r win-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
-  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r linux-x64 --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
+  - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r linux-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
   - dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r osx-x64 -c Debug --self-contained true --version-suffix %APPVEYOR_REPO_COMMIT% -p:PublishSingleFile=true
 
   # .NET 7.0 Release

--- a/publish-nix.sh
+++ b/publish-nix.sh
@@ -25,10 +25,10 @@ dotnet restore
 
 # .NET 6.0 Debug
 echo "Building .NET 6.0 debug"
-#dotnet publish MPF/MPF.csproj -f net6.0-windows -r win-x64 --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r win-x64 --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r linux-x64 --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r osx-x64 --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
+#dotnet publish MPF/MPF.csproj -f net6.0-windows -r win-x64 -c Debug --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
+dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r win-x64 -c Debug --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
+dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r linux-x64 -c Debug --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
+dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r osx-x64 -c Debug --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
 
 # .NET 6.0 Release
 echo "Building .NET 6.0 release"
@@ -39,10 +39,10 @@ dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r osx-x64 -c Release --self
 
 # .NET 7.0 Debug
 echo "Building .NET 7.0 debug"
-#dotnet publish MPF/MPF.csproj -f net7.0-windows -r win-x64 --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r win-x64 --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r linux-x64 --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r osx-x64 --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
+#dotnet publish MPF/MPF.csproj -f net7.0-windows -r win-x64 -c Debug --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
+dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r win-x64 -c Debug --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
+dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r linux-x64 -c Debug --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
+dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r osx-x64 -c Debug --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true
 
 # .NET 7.0 Release
 echo "Building .NET 7.0 release"

--- a/publish-nix.sh
+++ b/publish-nix.sh
@@ -32,10 +32,10 @@ dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r osx-x64 --self-contained 
 
 # .NET 6.0 Release
 echo "Building .NET 6.0 release"
-#dotnet publish MPF/MPF.csproj -f net6.0-windows -r win-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r win-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r linux-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r osx-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true
+#dotnet publish MPF/MPF.csproj -f net6.0-windows -r win-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r win-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r linux-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check/MPF.Check.csproj -f net6.0 -r osx-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false
 
 # .NET 7.0 Debug
 echo "Building .NET 7.0 debug"
@@ -46,10 +46,10 @@ dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r osx-x64 --self-contained 
 
 # .NET 7.0 Release
 echo "Building .NET 7.0 release"
-#dotnet publish MPF/MPF.csproj -f net7.0-windows -r win-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r win-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r linux-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true
-dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r osx-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true
+#dotnet publish MPF/MPF.csproj -f net7.0-windows -r win-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r win-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r linux-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check/MPF.Check.csproj -f net7.0 -r osx-x64 -c Release --self-contained true --version-suffix $COMMIT -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false
 
 # Create MPF Debug archives
 #cd $BUILD_FOLDER/MPF/bin/Debug/net6.0-windows/win-x64/publish/

--- a/publish-win.bat
+++ b/publish-win.bat
@@ -23,41 +23,41 @@ dotnet restore
 
 REM .NET Framework 4.8 Debug
 echo Building .NET Framework 4.8 debug
-dotnet publish MPF\MPF.csproj -f net48 -r win7-x64 --self-contained true --version-suffix %COMMIT%
-dotnet publish MPF.Check\MPF.Check.csproj -f net48 -r win7-x64 --self-contained true --version-suffix %COMMIT%
+dotnet publish MPF\MPF.csproj -f net48 -r win7-x64 -c Debug --self-contained true --version-suffix %COMMIT%
+dotnet publish MPF.Check\MPF.Check.csproj -f net48 -r win7-x64 -c Debug --self-contained true --version-suffix %COMMIT%
 
 REM .NET Framework 4.8 Release
 echo Building .NET Framework 4.8 release
-dotnet publish MPF\MPF.csproj -f net48 -c Release -r win7-x64 --self-contained true --version-suffix %COMMIT%
-dotnet publish MPF.Check\MPF.Check.csproj -f net48 -c Release -r win7-x64 --self-contained true --version-suffix %COMMIT%
+dotnet publish MPF\MPF.csproj -f net48 -r win7-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check\MPF.Check.csproj -f net48 -r win7-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:DebugType=None -p:DebugSymbols=false
 
 REM .NET 6.0 Debug
 echo Building .NET 6.0 debug
-dotnet publish MPF\MPF.csproj -f net6.0-windows -r win-x64 --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r win-x64 --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r linux-x64 --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r osx-x64 --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
+dotnet publish MPF\MPF.csproj -f net6.0-windows -r win-x64 -c Debug --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
+dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r win-x64 -c Debug --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
+dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r linux-x64 -c Debug --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
+dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r osx-x64 -c Debug --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
 
 REM .NET 6.0 Release
 echo Building .NET 6.0 release
-dotnet publish MPF\MPF.csproj -f net6.0-windows -r win-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r win-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r linux-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r osx-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
+dotnet publish MPF\MPF.csproj -f net6.0-windows -r win-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r win-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r linux-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check\MPF.Check.csproj -f net6.0 -r osx-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
 
 REM .NET 7.0 Debug
 echo Building .NET 7.0 debug
-dotnet publish MPF\MPF.csproj -f net7.0-windows -r win-x64 --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r win-x64 --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r linux-x64 --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r osx-x64 --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
+dotnet publish MPF\MPF.csproj -f net7.0-windows -r win-x64 -c Debug --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
+dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r win-x64 -c Debug --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
+dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r linux-x64 -c Debug --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
+dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r osx-x64 -c Debug --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
 
 REM .NET 7.0 Release
 echo Building .NET 7.0 release
-dotnet publish MPF\MPF.csproj -f net7.0-windows -r win-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r win-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r linux-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
-dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r osx-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true
+dotnet publish MPF\MPF.csproj -f net7.0-windows -r win-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r win-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r linux-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+dotnet publish MPF.Check\MPF.Check.csproj -f net7.0 -r osx-x64 -c Release --self-contained true --version-suffix %COMMIT% -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false
 
 REM Create MPF Debug archives
 cd %BUILD_FOLDER%\MPF\bin\Debug\net48\win7-x64\publish\


### PR DESCRIPTION
- Explicitly define debug profile in debug builds (For clarity, as Release profile becomes default in .NET 8)
- No debug symbols for release builds in appveyor build
- No debug symbols for release builds in win build script
- No debug symobls for release builds in nix build script

I've checked that it works on my appveyor build, but I havent tested the win/nix scripts so do check my changes :)