### PR TITLE
Clarify build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To build for .NET Framework 4.8, .NET 6.0, or .NET 7.0 (all Windows only), ensur
 dotnet build MPF\MPF.csproj --framework [net48|net6.0-windows|net7.0-windows] --runtime win-x64 --self-contained
 ```
 
-You may also run the `publish-win.bat` to build and package all variants MPF and MPF.Check at once. This script has the additional requirements of 7-zip commandline, Git for Windows, and .NET Framework 4.8 SDK being installed and in PATH.
+You may also run `publish-win.bat` (on Windows) or `publish-nix.sh` (on Linux) to build and package all variants MPF and MPF.Check at once. The Windows script additionally requires 7-zip commandline, Git for Windows, and .NET Framework 4.8 SDK to be installed and in PATH. The Linux script additionally requires `zip` and Git to be installed and in PATH.
 
 ## Media Preservation Frontend Checker (MPF.Check)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ To build for .NET Framework 4.8, .NET 6.0, or .NET 7.0 (all Windows only), ensur
 dotnet build MPF\MPF.csproj --framework [net48|net6.0-windows|net7.0-windows] --runtime win-x64 --self-contained
 ```
 
+You may also run the `publish-win.bat` to build and package all variants MPF and MPF.Check at once. This script has the additional requirements of 7-zip commandline, Git for Windows, and .NET Framework 4.8 SDK being installed and in PATH.
+
 ## Media Preservation Frontend Checker (MPF.Check)
 
 MPF.Check is a commandline-only program that allows users to generate submission information from their personal rips. This program supports the outputs from Redumper, Aaru, DiscImageCreator, Cleanrip, and UmdImageCreator. Running this program without any parameters will display the help text, including all supported parameters.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MPF is the main, UI-centric application of the MPF suite. This program allows us
 
 ### System Requirements
 
-- Windows 8.1 (x86 or x64) or newer
+- Windows 8.1 (x64) or newer
     - Users who wish to use MPF on Windows 7 need to disable strong name validation due to `Microsoft.Management.Infrastructure` being unsigned. Add the following registry keys (accurate at time of writing):
     ```
         [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\StrongName\Verification\*,31bf3856ad364e35]
@@ -27,7 +27,7 @@ MPF is the main, UI-centric application of the MPF suite. This program allows us
     ```
     - Alternatively, look at this [StackOverflow question](https://stackoverflow.com/questions/403731/strong-name-validation-failed) for more information.
 
-- .NET Framework 4.8 .NET 6.0, or .NET 7.0 Runtimes
+- .NET Framework 4.8, .NET 6.0, or .NET 7.0 Runtimes
 - As much hard drive space as the amount of discs you will be dumping (20+ GB recommended)
 
 Ensure that your operating system is as up-to-date as possible, since some features may rely on those updates.
@@ -45,7 +45,7 @@ The main UI has some known limitations that are documented in code and in some p
 To build for .NET Framework 4.8, .NET 6.0, or .NET 7.0 (all Windows only), ensure that the .NET 7.0 SDK (or later) is installed and included in your PATH. Then, run the following commands from command prompt, Powershell, or Terminal:
 
 ```
-dotnet build MPF\MPF.csproj --framework [net48|net6.0-windows|net7.0-windows] --runtime [win-x64]
+dotnet build MPF\MPF.csproj --framework [net48|net6.0-windows|net7.0-windows] --runtime win-x64 --self-contained
 ```
 
 ## Media Preservation Frontend Checker (MPF.Check)
@@ -54,7 +54,7 @@ MPF.Check is a commandline-only program that allows users to generate submission
 
 ### System Requirements
 
-- Windows 8.1 (x86 or x64) or newer, GNU/Linux x64, or OSX x64
+- Windows 8.1 (x64) or newer, GNU/Linux x64, or OSX x64
 - .NET Framework 4.8 (Windows or `mono` only), .NET 6.0, or .NET 7.0 Runtimes
 
 ### Build Instructions
@@ -62,7 +62,7 @@ MPF.Check is a commandline-only program that allows users to generate submission
 To build for .NET Framework 4.8 (Windows only), .NET 6.0, and .NET 7.0 (both all supported OSes), ensure that the .NET 7.0 SDK (or later) is installed and included in your PATH. Then, run the following commands from command prompt, Powershell, Terminal, or shell:
 
 ```
-dotnet build MPF.Check\MPF.Check.csproj --framework [net48|net6.0|net7.0] --runtime [win-x64linux-x64|osx-x64]
+dotnet build MPF.Check\MPF.Check.csproj --framework [net48|net6.0|net7.0] --runtime [win-x64|linux-x64|osx-x64] --self-contained
 ```
 
 Choose one of `[win-x64|linux-x64|osx-x64]` depending on the machine you are targeting.


### PR DESCRIPTION
I have built MPF using the build instructions and have some minor fixes to the readme to make
* Mention the publish-win.bat/publish-nix.sh scripts and expand on their requirements.
* Remove 32bit from system requirements
* Add self-contained to build commands to remove warning, as runtime is defined
* Add a missing `|` in the MPF.Check build command
* Add a missing comma