### PR TITLE
Fix media combobox not updating

### DIFF
--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -1326,9 +1326,6 @@ namespace MPF.Core.UI.ViewModels
             Result result = Tools.GetSupportStatus(_environment.System, _environment.Type);
             this.Status = result.Message;
 
-            // Set the index for the current disc type
-            SetCurrentDiscType();
-
             // Enable or disable the button
             this.StartStopButtonEnabled = result && ShouldEnableDumpingButton();
 
@@ -1522,8 +1519,6 @@ namespace MPF.Core.UI.ViewModels
                 if (detectedIndex > -1)
                 {
                     CurrentMediaType = _detectedMediaType;
-                    // Clear detected media type after first use, so combo box may be changed
-                    _detectedMediaType = null;
                     return;
                 }
             }

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -1522,6 +1522,8 @@ namespace MPF.Core.UI.ViewModels
                 if (detectedIndex > -1)
                 {
                     CurrentMediaType = _detectedMediaType;
+                    // Clear detected media type after first use, so combo box may be changed
+                    _detectedMediaType = null;
                     return;
                 }
             }


### PR DESCRIPTION
The media type combo box was not updating on user selection, due to the detected media type being chosen first.
I have solved this by clearing the detected media type variable once it has been used.

If you want to preserve the variable, then you can fix this a cleaner way, however pressing 'Scan for discs' does still revert the combo box to the detected media, so this change does do as expected.