### PR TITLE
Disable dumping button when Redumper selected with unsupported media type

### DIFF
--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -1584,6 +1584,35 @@ namespace MPF.Core.UI.ViewModels
         }
 
         /// <summary>
+        /// Returns False if a given InternalProgram does not support a given MediaType
+        /// </summary>
+        public bool ProgramSupportsMedia(InternalProgram program, MediaType? media)
+        {
+            switch (program)
+            {
+                case InternalProgram.Redumper:
+                    switch (media)
+                    {
+                        case MediaType.HDDVD:
+                            return false;
+                        case MediaType.BluRay:
+                            return false;
+                        default:
+                            return true;
+                    }
+                case InternalProgram.Aaru:
+                case InternalProgram.DiscImageCreator:
+                    switch (media)
+                    {
+                        default:
+                            return true;
+                    }
+                default:
+                    return true;
+            }
+        }
+
+        /// <summary>
         /// Determine if the dumping button should be enabled
         /// </summary>
         private bool ShouldEnableDumpingButton()
@@ -1592,8 +1621,7 @@ namespace MPF.Core.UI.ViewModels
                 && Drives.Count > 0
                 && this.CurrentSystem != null
                 && this.CurrentMediaType != null
-                && (this.CurrentMediaType != MediaType.BluRay || this.CurrentProgram != InternalProgram.Redumper)
-                && (this.CurrentMediaType != MediaType.HDDVD || this.CurrentProgram != InternalProgram.Redumper);
+                && ProgramSupportsMedia(this.CurrentProgram, this.CurrentMediaType);
         }
 
         /// <summary>

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -1592,6 +1592,7 @@ namespace MPF.Core.UI.ViewModels
                 && Drives.Count > 0
                 && this.CurrentSystem != null
                 && this.CurrentMediaType != null
+                && (this.CurrentMediaType != MediaType.BluRay || this.CurrentProgram != InternalProgram.Redumper)
                 && (this.CurrentMediaType != MediaType.HDDVD || this.CurrentProgram != InternalProgram.Redumper);
         }
 

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -1586,7 +1586,11 @@ namespace MPF.Core.UI.ViewModels
         /// <summary>
         /// Returns False if a given InternalProgram does not support a given MediaType
         /// </summary>
+#if NET48
         public bool ProgramSupportsMedia(InternalProgram program, MediaType? media)
+#else
+        public bool ProgramSupportsMedia(InternalProgram program, MediaType media)
+#endif
         {
             switch (program)
             {

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -1586,11 +1586,7 @@ namespace MPF.Core.UI.ViewModels
         /// <summary>
         /// Returns False if a given InternalProgram does not support a given MediaType
         /// </summary>
-#if NET48
-        public bool ProgramSupportsMedia(InternalProgram program, MediaType media)
-#else
         public bool ProgramSupportsMedia(InternalProgram program, MediaType? media)
-#endif
         {
             switch (program)
             {

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -1587,9 +1587,9 @@ namespace MPF.Core.UI.ViewModels
         /// Returns False if a given InternalProgram does not support a given MediaType
         /// </summary>
 #if NET48
-        public bool ProgramSupportsMedia(InternalProgram program, MediaType? media)
-#else
         public bool ProgramSupportsMedia(InternalProgram program, MediaType media)
+#else
+        public bool ProgramSupportsMedia(InternalProgram program, MediaType? media)
 #endif
         {
             switch (program)

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -1591,7 +1591,8 @@ namespace MPF.Core.UI.ViewModels
             return Drives != null
                 && Drives.Count > 0
                 && this.CurrentSystem != null
-                && this.CurrentMediaType != null;
+                && this.CurrentMediaType != null
+                && (this.CurrentMediaType != MediaType.HDDVD || this.CurrentProgram != InternalProgram.Redumper);
         }
 
         /// <summary>


### PR DESCRIPTION
Naive solution to #514 
~~Does a check for HDDVD+Redumper every time.
This line can be removed if/when redumper supports HD-DVDs.
Happy to close this if a better solution is worked on.~~
Created helper function that checks whether a given program supports a given media.
Only implemented checks for Redumper + HDDVD or Bluray currently.