### PR TITLE
Set UDF CD threshold at 800MB

### DIFF
--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -265,13 +265,9 @@ namespace MPF.Core.Data
             }
 
             // Handle optical media by size and filesystem
-            if (this.TotalSize >= 0 && this.TotalSize <= 800_000_000 && this.DriveFormat == "CDFS")
+            if (this.TotalSize >= 0 && this.TotalSize <= 800_000_000 && (this.DriveFormat == "CDFS" || this.DriveFormat == "UDF"))
                 return (MediaType.CDROM, null);
-            else if (this.TotalSize >= 0 && this.TotalSize <= 800_000_000 && this.DriveFormat == "UDF")
-                return (MediaType.CDROM, null);
-            else if (this.TotalSize > 800_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "CDFS")
-                return (MediaType.DVD, null);
-            else if (this.TotalSize > 800_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "UDF")
+            else if (this.TotalSize > 800_000_000 && this.TotalSize <= 8_540_000_000 && (this.DriveFormat == "CDFS" || this.DriveFormat == "UDF"))
                 return (MediaType.DVD, null);
             else if (this.TotalSize > 8_540_000_000)
                 return (MediaType.BluRay, null);

--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -265,13 +265,13 @@ namespace MPF.Core.Data
             }
 
             // Handle optical media by size and filesystem
-            if (this.TotalSize >= 0 && this.TotalSize < 800_000_000 && this.DriveFormat == "CDFS")
+            if (this.TotalSize >= 0 && this.TotalSize <= 800_000_000 && this.DriveFormat == "CDFS")
                 return (MediaType.CDROM, null);
-            else if (this.TotalSize >= 0 && this.TotalSize < 400_000_000 && this.DriveFormat == "UDF")
+            else if (this.TotalSize >= 0 && this.TotalSize <= 800_000_000 && this.DriveFormat == "UDF")
                 return (MediaType.CDROM, null);
-            else if (this.TotalSize >= 800_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "CDFS")
+            else if (this.TotalSize > 800_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "CDFS")
                 return (MediaType.DVD, null);
-            else if (this.TotalSize >= 400_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "UDF")
+            else if (this.TotalSize > 800_000_000 && this.TotalSize <= 8_540_000_000 && this.DriveFormat == "UDF")
                 return (MediaType.DVD, null);
             else if (this.TotalSize > 8_540_000_000)
                 return (MediaType.BluRay, null);


### PR DESCRIPTION
Currently, optical media type detection for UDF filesystems is set to DVDs if the size is at least 400MB.

Based on the PC CDs and DVDs in redump, the false positive rate for DVD detection when using a threshold of 800 MB is less than 3%, with an optimal threshold for CD and DVD false detection rate at approx 830MB. However, I think it is best that MPF keep the threshold at 800 MB as CDs greater than 800 MB in size are technically not following the CD-ROM standard.

I have also changed it slightly to set discs with exactly 800 MB as CDs.

Cumulative distributions for PC DVDs (in red) and PC CDs (in blue) with regards to size, where the crossover represents the point with the "lowest false detection rate":
![false-positive](https://github.com/SabreTools/MPF/assets/138427222/76600786-8a5f-42ab-ba16-d29b940041dc)
![crossover](https://github.com/SabreTools/MPF/assets/138427222/730a0284-3fbf-45a9-84cb-9eb335d2aafe)
