### PR TITLE
Always use relative path internally

### DIFF
--- a/MPF.Core/DumpEnvironment.cs
+++ b/MPF.Core/DumpEnvironment.cs
@@ -133,7 +133,7 @@ namespace MPF.Core
             Options = options;
 
             // Output paths
-            OutputPath = InfoTool.NormalizeOutputPaths(outputPath, true);
+            OutputPath = InfoTool.NormalizeOutputPaths(outputPath, false);
 
             // UI information
             Drive = drive;
@@ -575,7 +575,7 @@ namespace MPF.Core
                 return Result.Failure("Error! Current configuration is not supported!");
 
             // Fix the output paths, just in case
-            OutputPath = InfoTool.NormalizeOutputPaths(OutputPath, true);
+            OutputPath = InfoTool.NormalizeOutputPaths(OutputPath, false);
 
             // Validate that the output path isn't on the dumping drive
             if (Drive?.Name != null && OutputPath.StartsWith(Drive.Name))

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -1451,7 +1451,7 @@ namespace MPF.Core.UI.ViewModels
             // Disable change handling
             DisableEventHandlers();
 
-            this.OutputPath = InfoTool.NormalizeOutputPaths(_environment.Parameters?.OutputPath, true);
+            this.OutputPath = InfoTool.NormalizeOutputPaths(_environment.Parameters?.OutputPath, false);
 
             if (MediaTypes != null)
             {


### PR DESCRIPTION
Set the getFullPath flags to false in the 3 places in MPF that still use full paths (except in MPF.Test).

I have tested this for one disc and had no issues with redumper or DIC, but this probably should be tested with aaru by someone who knows what they're doing.