### PR TITLE
Remove psxt001z Pkg Ref in MPF.Test

### DIFF
--- a/MPF.Test/MPF.Test.csproj
+++ b/MPF.Test/MPF.Test.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.CodeCoverage" Version="17.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="psxt001z" Version="0.21.0-beta1" />
     <PackageReference Include="SabreTools.RedumpLib" Version="1.1.1" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />


### PR DESCRIPTION
The only `using` for psxt001z inside MPF.Test was deleted but the csproj still has it as a reference.

Note:
It would be nice to put the Libcrypt check from psxt001z into BOS, having the LibCrypt check require its own library doesn't make sense, especially since its only ever used once inside MPF.Core/Protection.cs: https://github.com/SabreTools/MPF/blob/master/MPF.Core/Protection.cs#L142
But I'll leave that to you to decide, I know it's not originally your code.