### PR TITLE
Focus main window after child window closes

### DIFF
--- a/MPF.UI.Core/Windows/MainWindow.xaml.cs
+++ b/MPF.UI.Core/Windows/MainWindow.xaml.cs
@@ -227,6 +227,8 @@ namespace MPF.UI.Core.Windows
                 ShowInTaskbar = true,
                 WindowStartupLocation = WindowStartupLocation.CenterOwner,
             };
+
+            discInformationWindow.Closed += delegate { this.Activate(); };
             bool? result = discInformationWindow.ShowDialog();
 
             // Copy back the submission info changes, if necessary
@@ -263,6 +265,7 @@ namespace MPF.UI.Core.Windows
                 WindowStartupLocation = WindowStartupLocation.CenterOwner,
             };
 
+            optionsWindow.Closed += delegate { this.Activate(); };
             optionsWindow.Closed += OnOptionsUpdated;
             optionsWindow.Show();
         }


### PR DESCRIPTION
Occasionally, the main window hides behind another application after the options window or disc information window is closed.
To replicate current problem:
1. Go to Options
2. Go to the Paths tab, then click on a `...` button so that the windows explorer window pops up
3. Close this window, then close the options window
4. The Main MPF window gets hidden behind previously opened application.

This attempts to solve the problem, but feels like a band-aid solution.
Open to other ideas.