### PR TITLE
Pull PS3 Firmware Version

### DIFF
--- a/MPF.Core/InfoTool.cs
+++ b/MPF.Core/InfoTool.cs
@@ -811,8 +811,7 @@ namespace MPF.Core
                     br.Read(buf, 0, 2);
                     short location = BitConverter.ToInt16(buf, 0);
                     br.BaseStream.Seek(location, SeekOrigin.Begin);
-                    string version = new string(br.ReadChars(4));
-                    return "PS3 Firmware " + version;
+                    return new string(br.ReadChars(4));
                 }
             }
             catch

--- a/MPF.Core/InfoTool.cs
+++ b/MPF.Core/InfoTool.cs
@@ -798,29 +798,28 @@ namespace MPF.Core
                 return null;
 
             // Attempt to read from /PS3_UPDATE/PS3UPDAT.PUP
-            string pupPath = Path.Combine(drivePath, "PS3_UPDATE\\PS3UPDAT.PUP");
-            if (File.Exists(pupPath))
+            string pupPath = Path.Combine(drivePath, "PS3_UPDATE", "PS3UPDAT.PUP");
+            if (!File.Exists(pupPath))
+                return null;
+
+            try
             {
-                try
+                using (var br = new BinaryReader(File.OpenRead(pupPath)))
                 {
-                    using (var br = new BinaryReader(File.OpenRead(pupPath)))
-                    {
-                        br.BaseStream.Seek(0x3E, SeekOrigin.Begin);
-                        byte[] buf = new byte[2];
-                        br.Read(buf, 0, 2);
-                        long location = BitConverter.ToInt32(buf, 0);
-                        br.BaseStream.Seek(location, SeekOrigin.Begin);
-                        return new string(br.ReadChars(4));
-                    }
-                }
-                catch
-                {
-                    // We don't care what the error was
-                    return null;
+                    br.BaseStream.Seek(0x3E, SeekOrigin.Begin);
+                    byte[] buf = new byte[2];
+                    br.Read(buf, 0, 2);
+                    short location = BitConverter.ToInt16(buf, 0);
+                    br.BaseStream.Seek(location, SeekOrigin.Begin);
+                    string version = new string(br.ReadChars(4));
+                    return "PS3 Firmware " + version;
                 }
             }
-
-            return null;
+            catch
+            {
+                // We don't care what the error was
+                return null;
+            }
         }
 
         /// <summary>

--- a/MPF.Core/InfoTool.cs
+++ b/MPF.Core/InfoTool.cs
@@ -809,6 +809,7 @@ namespace MPF.Core
                     br.BaseStream.Seek(0x3E, SeekOrigin.Begin);
                     byte[] buf = new byte[2];
                     br.Read(buf, 0, 2);
+                    Array.Reverse(buf);
                     short location = BitConverter.ToInt16(buf, 0);
                     br.BaseStream.Seek(location, SeekOrigin.Begin);
                     return new string(br.ReadChars(4));

--- a/MPF.Core/Modules/Aaru/Parameters.cs
+++ b/MPF.Core/Modules/Aaru/Parameters.cs
@@ -605,9 +605,11 @@ namespace MPF.Core.Modules.Aaru
 #if NET48
                     info.VersionAndEditions.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
                     info.CommonDiscInfo.CommentsSpecialFields[SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
+                    info.CommonDiscInfo.CommentsSpecialFields[SiteCode.Patches] = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name) ?? string.Empty;
 #else
                     info.VersionAndEditions!.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
                     info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
+                    info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Patches] = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name) ?? string.Empty;
 #endif
                     break;
 

--- a/MPF.Core/Modules/Aaru/Parameters.cs
+++ b/MPF.Core/Modules/Aaru/Parameters.cs
@@ -605,11 +605,15 @@ namespace MPF.Core.Modules.Aaru
 #if NET48
                     info.VersionAndEditions.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
                     info.CommonDiscInfo.CommentsSpecialFields[SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
-                    info.CommonDiscInfo.CommentsSpecialFields[SiteCode.Patches] = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name) ?? string.Empty;
+                    string firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
+                    if (firmwareVersion != null)
+                        info.CommonDiscInfo.CommentsSpecialFields[SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #else
                     info.VersionAndEditions!.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
                     info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
-                    info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Patches] = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name) ?? string.Empty;
+                    string? firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
+                    if (firmwareVersion != null)
+                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #endif
                     break;
 

--- a/MPF.Core/Modules/Aaru/Parameters.cs
+++ b/MPF.Core/Modules/Aaru/Parameters.cs
@@ -607,13 +607,13 @@ namespace MPF.Core.Modules.Aaru
                     info.CommonDiscInfo.CommentsSpecialFields[SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
                     string firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
                     if (firmwareVersion != null)
-                        info.CommonDiscInfo.CommentsSpecialFields[SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
+                        info.CommonDiscInfo.ContentsSpecialFields[SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #else
                     info.VersionAndEditions!.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
                     info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
                     string? firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
                     if (firmwareVersion != null)
-                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
+                        info.CommonDiscInfo!.ContentsSpecialFields![SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #endif
                     break;
 

--- a/MPF.Core/Modules/DiscImageCreator/Parameters.cs
+++ b/MPF.Core/Modules/DiscImageCreator/Parameters.cs
@@ -1032,9 +1032,15 @@ namespace MPF.Core.Modules.DiscImageCreator
 #if NET48
                     info.VersionAndEditions.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
                     info.CommonDiscInfo.CommentsSpecialFields[SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
+                    string firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
+                    if (firmwareVersion != null)
+                        info.CommonDiscInfo.CommentsSpecialFields[SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #else
                     info.VersionAndEditions!.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
                     info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
+                    string? firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
+                    if (firmwareVersion != null)
+                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #endif
                     break;
 

--- a/MPF.Core/Modules/DiscImageCreator/Parameters.cs
+++ b/MPF.Core/Modules/DiscImageCreator/Parameters.cs
@@ -1034,13 +1034,13 @@ namespace MPF.Core.Modules.DiscImageCreator
                     info.CommonDiscInfo.CommentsSpecialFields[SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
                     string firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
                     if (firmwareVersion != null)
-                        info.CommonDiscInfo.CommentsSpecialFields[SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
+                        info.CommonDiscInfo.ContentsSpecialFields[SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #else
                     info.VersionAndEditions!.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
                     info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
                     string? firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
                     if (firmwareVersion != null)
-                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
+                        info.CommonDiscInfo!.ContentsSpecialFields![SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #endif
                     break;
 

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -607,13 +607,13 @@ namespace MPF.Core.Modules.Redumper
                     info.CommonDiscInfo.CommentsSpecialFields[SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
                     string firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
                     if (firmwareVersion != null)
-                        info.CommonDiscInfo.CommentsSpecialFields[SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
+                        info.CommonDiscInfo.ContentsSpecialFields[SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #else
                     info.VersionAndEditions!.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
                     info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
                     string? firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
                     if (firmwareVersion != null)
-                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
+                        info.CommonDiscInfo!.ContentsSpecialFields![SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #endif
                     break;
 

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -605,9 +605,15 @@ namespace MPF.Core.Modules.Redumper
 #if NET48
                     info.VersionAndEditions.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
                     info.CommonDiscInfo.CommentsSpecialFields[SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
+                    string firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
+                    if (firmwareVersion != null)
+                        info.CommonDiscInfo.CommentsSpecialFields[SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #else
                     info.VersionAndEditions!.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
                     info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
+                    string? firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
+                    if (firmwareVersion != null)
+                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
 #endif
                     break;
 


### PR DESCRIPTION
This pulls the PS3 firmware update version (from /PS3_UPDATE/PS3UPDAT.PUP) and puts `PS3 Firmware 1.00` etc in the Patches field.
Implements #597 

Please squash merge :)