### PR TITLE
Enable browsing for Redumper path

### DIFF
--- a/MPF.UI.Core/Windows/OptionsWindow.xaml.cs
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml.cs
@@ -33,6 +33,7 @@ namespace MPF.UI.Core.Windows
             // Add handlers
             AaruPathButton.Click += BrowseForPathClick;
             DiscImageCreatorPathButton.Click += BrowseForPathClick;
+            RedumperPathButton.Click += BrowseForPathClick;
             DefaultOutputPathButton.Click += BrowseForPathClick;
 
             AcceptButton.Click += OnAcceptClick;


### PR DESCRIPTION
The options window currently has a non-functional button to browse for the Redumper executable.
This enables it.