### PR TITLE
Update to MMI 3.0.0

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -8,6 +8,7 @@
 - Pull PS3 Firmware Version (Deterous)
 - Fix default layerbreak output
 - Enable browsing for Redumper path (Deterous)
+- Update to MMI 3.0.0 (Deterous)
 
 ### 2.7.4 (2023-10-31)
 

--- a/MPF.Core/MPF.Core.csproj
+++ b/MPF.Core/MPF.Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="BurnOutSharp" PrivateAssets="build; analyzers" ExcludeAssets="contentFiles" Version="2.9.0" GeneratePathProperty="true">
       <IncludeAssets>runtime; compile; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0-preview.4" />
+    <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="psxt001z" Version="0.21.0-beta1" />
     <PackageReference Include="SabreTools.Models" Version="1.1.5" />


### PR DESCRIPTION
The non-preview version of MMI 3.0.0 has released, MPF can now use it.