### PR TITLE
Support redumper skeleton and hash files

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -5,6 +5,7 @@
 - Fix commented out code
 - Make missing hash data clearer
 - Get BD PIC Identifier for redumper (Deterous)
+- Support redumper skeleton and hash files (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/MPF.Core.csproj
+++ b/MPF.Core/MPF.Core.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="psxt001z.Library" Version="0.21.0-beta3" />
     <PackageReference Include="SabreTools.Models" Version="1.3.0" />
     <PackageReference Include="SabreTools.RedumpLib" Version="1.3.2" />
-    <PackageReference Include="SabreTools.Serialization" Version="1.3.0" />
+    <PackageReference Include="SabreTools.Serialization" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -885,14 +885,14 @@ namespace MPF.Core.Modules.Redumper
                         foreach (CueFile? file in cueSheet.Files)
                         {
                             string? trackName = Path.GetFileNameWithoutExtension(file?.FileName);
-                            if (trackName != null)
-                            {
-                                string trackPath = Path.Combine(baseDir, trackName);
-                                if (File.Exists($"{trackPath}.hash"))
-                                    logFiles.Add($"{trackPath}.hash");
-                                if (File.Exists($"{trackPath}.skeleton"))
-                                    logFiles.Add($"{trackPath}.skeleton");
-                            }
+                            if (trackName == null)
+                                continue;
+
+                            string trackPath = Path.Combine(baseDir, trackName);
+                            if (File.Exists($"{trackPath}.hash"))
+                                logFiles.Add($"{trackPath}.hash");
+                            if (File.Exists($"{trackPath}.skeleton"))
+                                logFiles.Add($"{trackPath}.skeleton");
                         }
                     }
                     else

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using MPF.Core.Converters;
 using MPF.Core.Data;
+using SabreTools.Models.CueSheets;
 using SabreTools.RedumpLib;
 using SabreTools.RedumpLib.Data;
 
@@ -206,8 +207,12 @@ namespace MPF.Core.Modules.Redumper
                     //        missingFiles.Add($"{basePath}.cdtext");
                     //
                     //    // Not available in all versions
+                    //    if (!File.Exists($"{basePath}.hash"))
+                    //        missingFiles.Add($"{basePath}.hash");
+                    //    // Also: "{basePath} (Track X).hash" (get from cuesheet)
                     //    if (!File.Exists($"{basePath}.skeleton"))
                     //        missingFiles.Add($"{basePath}.skeleton");
+                    //    // Also: "{basePath} (Track X).skeleton" (get from cuesheet)
                     //}
 
                     break;
@@ -230,6 +235,8 @@ namespace MPF.Core.Modules.Redumper
                     // Removed or inconsistent files
                     //{
                     //    // Not available in all versions
+                    //    if (!File.Exists($"{basePath}.hash"))
+                    //        missingFiles.Add($"{basePath}.hash");
                     //    if (!File.Exists($"{basePath}.skeleton"))
                     //        missingFiles.Add($"{basePath}.skeleton");
                     //}
@@ -253,6 +260,8 @@ namespace MPF.Core.Modules.Redumper
                     // Removed or inconsistent files
                     //{
                     //    // Not available in all versions
+                    //    if (!File.Exists($"{basePath}.hash"))
+                    //        missingFiles.Add($"{basePath}.hash");
                     //    if (!File.Exists($"{basePath}.skeleton"))
                     //        missingFiles.Add($"{basePath}.skeleton");
                     //}
@@ -507,6 +516,9 @@ namespace MPF.Core.Modules.Redumper
                     info.Artifacts["cue"] = GetBase64(GetFullFile($"{basePath}.cue")) ?? string.Empty;
                 if (File.Exists($"{basePath}.fulltoc"))
                     info.Artifacts["fulltoc"] = GetBase64(GetFullFile($"{basePath}.fulltoc")) ?? string.Empty;
+                // if (File.Exists($"{basePath}.hash"))
+                //     info.Artifacts["hash"] = GetBase64(GetFullFile($"{basePath}.hash")) ?? string.Empty;
+                // // Also: "{basePath} (Track X).hash" (get from cuesheet)
                 if (File.Exists($"{basePath}.log"))
                     info.Artifacts["log"] = GetBase64(GetFullFile($"{basePath}.log")) ?? string.Empty;
                 if (File.Exists($"{basePath}.manufacturer"))
@@ -523,6 +535,7 @@ namespace MPF.Core.Modules.Redumper
                     info.Artifacts["physical2"] = GetBase64(GetFullFile($"{basePath}.2.physical")) ?? string.Empty;
                 // if (File.Exists($"{basePath}.skeleton"))
                 //     info.Artifacts["skeleton"] = GetBase64(GetFullFile($"{basePath}.skeleton")) ?? string.Empty;
+                // // Also: "{basePath} (Track X).skeleton" (get from cuesheet)
                 // if (File.Exists($"{basePath}.scram"))
                 //     info.Artifacts["scram"] = GetBase64(GetFullFile($"{basePath}.scram")) ?? string.Empty;
                 // if (File.Exists($"{basePath}.scrap"))
@@ -854,17 +867,39 @@ namespace MPF.Core.Modules.Redumper
                         logFiles.Add($"{basePath}.fulltoc");
                     if (File.Exists($"{basePath}.log"))
                         logFiles.Add($"{basePath}.log");
-                    if (File.Exists($"{basePath}.skeleton"))
-                        logFiles.Add($"{basePath}.skeleton");
                     if (File.Exists($"{basePath}.state"))
                         logFiles.Add($"{basePath}.state");
                     if (File.Exists($"{basePath}.subcode"))
                         logFiles.Add($"{basePath}.subcode");
                     if (File.Exists($"{basePath}.toc"))
                         logFiles.Add($"{basePath}.toc");
+
+                    // Include .hash and .skeleton for all files in cuesheet
+                    CueSheet? cueSheet = new SabreTools.Serialization.Files.CueSheet().Deserialize($"{basePath}.cue");
+                    if (cueSheet != default && cueSheet.Files != null)
+                    {
+                        foreach (CueFile? file in cueSheet.Files)
+                        {
+                            string trackPath = $"{Path.GetDirectoryName(basePath)}\\{Path.GetFileNameWithoutExtension(file?.FileName)}";
+                            if (File.Exists($"{trackPath}.hash"))
+                                logFiles.Add($"{trackPath}.hash");
+                            if (File.Exists($"{trackPath}.skeleton"))
+                                logFiles.Add($"{trackPath}.skeleton");
+                        }
+                    }
+                    else
+                    {
+                        if (File.Exists($"{basePath}.hash"))
+                            logFiles.Add($"{basePath}.hash");
+                        if (File.Exists($"{basePath}.skeleton"))
+                            logFiles.Add($"{basePath}.skeleton");
+                    }
+
                     break;
 
                 case MediaType.DVD:
+                    if (File.Exists($"{basePath}.hash"))
+                        logFiles.Add($"{basePath}.hash");
                     if (File.Exists($"{basePath}.log"))
                         logFiles.Add($"{basePath}.log");
                     if (File.Exists($"{basePath}.manufacturer"))
@@ -887,6 +922,8 @@ namespace MPF.Core.Modules.Redumper
 
                 case MediaType.HDDVD: // TODO: Confirm that this information outputs
                 case MediaType.BluRay:
+                    if (File.Exists($"{basePath}.hash"))
+                        logFiles.Add($"{basePath}.hash");
                     if (File.Exists($"{basePath}.log"))
                         logFiles.Add($"{basePath}.log");
                     if (File.Exists($"{basePath}.physical"))

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -880,7 +880,7 @@ namespace MPF.Core.Modules.Redumper
                     {
                         foreach (CueFile? file in cueSheet.Files)
                         {
-                            string trackPath = $"{Path.Combine(Path.GetDirectoryName(basePath), Path.GetFileNameWithoutExtension(file?.FileName))}";
+                            string trackPath = Path.Combine(Path.GetDirectoryName(basePath), Path.GetFileNameWithoutExtension(file?.FileName));
                             if (File.Exists($"{trackPath}.hash"))
                                 logFiles.Add($"{trackPath}.hash");
                             if (File.Exists($"{trackPath}.skeleton"))

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -879,15 +879,20 @@ namespace MPF.Core.Modules.Redumper
 
                     // Include .hash and .skeleton for all files in cuesheet
                     var cueSheet = new SabreTools.Serialization.Files.CueSheet().Deserialize($"{basePath}.cue");
-                    if (cueSheet?.Files != null)
+                    string? baseDir = Path.GetDirectoryName(basePath);
+                    if (cueSheet?.Files != null && baseDir != null)
                     {
                         foreach (CueFile? file in cueSheet.Files)
                         {
-                            string trackPath = Path.Combine(Path.GetDirectoryName(basePath), Path.GetFileNameWithoutExtension(file?.FileName));
-                            if (File.Exists($"{trackPath}.hash"))
-                                logFiles.Add($"{trackPath}.hash");
-                            if (File.Exists($"{trackPath}.skeleton"))
-                                logFiles.Add($"{trackPath}.skeleton");
+                            string? trackName = Path.GetFileNameWithoutExtension(file?.FileName);
+                            if (trackName != null)
+                            {
+                                string trackPath = Path.Combine(baseDir, trackName);
+                                if (File.Exists($"{trackPath}.hash"))
+                                    logFiles.Add($"{trackPath}.hash");
+                                if (File.Exists($"{trackPath}.skeleton"))
+                                    logFiles.Add($"{trackPath}.skeleton");
+                            }
                         }
                     }
                     else

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -516,9 +516,9 @@ namespace MPF.Core.Modules.Redumper
                     info.Artifacts["cue"] = GetBase64(GetFullFile($"{basePath}.cue")) ?? string.Empty;
                 if (File.Exists($"{basePath}.fulltoc"))
                     info.Artifacts["fulltoc"] = GetBase64(GetFullFile($"{basePath}.fulltoc")) ?? string.Empty;
-                // if (File.Exists($"{basePath}.hash"))
-                //     info.Artifacts["hash"] = GetBase64(GetFullFile($"{basePath}.hash")) ?? string.Empty;
-                // // Also: "{basePath} (Track X).hash" (get from cuesheet)
+                if (File.Exists($"{basePath}.hash"))
+                    info.Artifacts["hash"] = GetBase64(GetFullFile($"{basePath}.hash")) ?? string.Empty;
+                // TODO: "{basePath} (Track X).hash" (get from cuesheet)
                 if (File.Exists($"{basePath}.log"))
                     info.Artifacts["log"] = GetBase64(GetFullFile($"{basePath}.log")) ?? string.Empty;
                 if (File.Exists($"{basePath}.manufacturer"))
@@ -875,12 +875,12 @@ namespace MPF.Core.Modules.Redumper
                         logFiles.Add($"{basePath}.toc");
 
                     // Include .hash and .skeleton for all files in cuesheet
-                    CueSheet? cueSheet = new SabreTools.Serialization.Files.CueSheet().Deserialize($"{basePath}.cue");
-                    if (cueSheet != default && cueSheet.Files != null)
+                    var cueSheet = new SabreTools.Serialization.Files.CueSheet().Deserialize($"{basePath}.cue");
+                    if (cueSheet?.Files != null)
                     {
                         foreach (CueFile? file in cueSheet.Files)
                         {
-                            string trackPath = $"{Path.GetDirectoryName(basePath)}\\{Path.GetFileNameWithoutExtension(file?.FileName)}";
+                            string trackPath = $"{Path.Combine(Path.GetDirectoryName(basePath), Path.GetFileNameWithoutExtension(file?.FileName))}";
                             if (File.Exists($"{trackPath}.hash"))
                                 logFiles.Add($"{trackPath}.hash");
                             if (File.Exists($"{trackPath}.skeleton"))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,8 +48,8 @@ after_build:
 - 7z e DiscImageCreator_20230606.zip -oMPF\bin\Debug\net8.0-windows\win-x64\publish\Programs\Creator Release_ANSI\*
 
 # Redumper
-- ps: appveyor DownloadFile https://github.com/superg/redumper/releases/download/build_306/redumper-2023.12.29_build306-win64.zip
-- 7z e redumper-2023.12.29_build306-win64.zip -oMPF\bin\Debug\net8.0-windows\win-x64\publish\Programs\Redumper redumper-2023.12.29_build306-win64\bin\*
+- ps: appveyor DownloadFile https://github.com/superg/redumper/releases/download/build_294/redumper-2023.12.08_build294-win64.zip
+- 7z e redumper-2023.12.08_build294-win64.zip -oMPF\bin\Debug\net8.0-windows\win-x64\publish\Programs\Redumper redumper-2023.12.08_build294-win64\bin\*
 
 # Create MPF Debug archives
 - cd %APPVEYOR_BUILD_FOLDER%\MPF\bin\Debug\net8.0-windows\win-x64\publish\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,8 +48,8 @@ after_build:
 - 7z e DiscImageCreator_20230606.zip -oMPF\bin\Debug\net8.0-windows\win-x64\publish\Programs\Creator Release_ANSI\*
 
 # Redumper
-- ps: appveyor DownloadFile https://github.com/superg/redumper/releases/download/build_294/redumper-2023.12.08_build294-win64.zip
-- 7z e redumper-2023.12.08_build294-win64.zip -oMPF\bin\Debug\net8.0-windows\win-x64\publish\Programs\Redumper redumper-2023.12.08_build294-win64\bin\*
+- ps: appveyor DownloadFile https://github.com/superg/redumper/releases/download/build_306/redumper-2023.12.29_build306-win64.zip
+- 7z e redumper-2023.12.29_build306-win64.zip -oMPF\bin\Debug\net8.0-windows\win-x64\publish\Programs\Redumper redumper-2023.12.29_build306-win64\bin\*
 
 # Create MPF Debug archives
 - cd %APPVEYOR_BUILD_FOLDER%\MPF\bin\Debug\net8.0-windows\win-x64\publish\


### PR DESCRIPTION
- Add .hash/.skeleton files to log zip, for track.iso, track.bin, and multi-track .bin files
- Update SabreTools.Serialization to 1.3.1

Attempts to fix #615 