### PR TITLE
Get BD PIC Identifier for redumper

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -4,6 +4,7 @@
 - Update Redumper to build 294
 - Fix commented out code
 - Make missing hash data clearer
+- Get BD PIC Identifier for redumper (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -363,6 +363,9 @@ namespace MPF.Core.Modules.Redumper
                         }
 
                         info.Extras!.PIC = GetPIC($"{basePath}.physical", trimLength) ?? string.Empty;
+
+                        var di = InfoTool.GetDiscInformation($"{basePath}.physical");
+                        info.SizeAndChecksums!.PICIdentifier = InfoTool.GetPICIdentifier(di);
                     }
 
                     break;


### PR DESCRIPTION
Identifies blu-ray PIC for redumper bluray discs.
Is required for small-sized BD-66 discs, to differentiate from BD-50.
Solves #617 