### PR TITLE
Cleanup !protectionInfo.txt

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -6,6 +6,7 @@
 - Make missing hash data clearer
 - Get BD PIC Identifier for redumper (Deterous)
 - Support redumper skeleton and hash files (Deterous)
+- Remove drive letter from !protectionInfo.txt (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -6,7 +6,7 @@
 - Make missing hash data clearer
 - Get BD PIC Identifier for redumper (Deterous)
 - Support redumper skeleton and hash files (Deterous)
-- Remove drive letter from !protectionInfo.txt (Deterous)
+- Cleanup !protectionInfo.txt (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/Data/Options.cs
+++ b/MPF.Core/Data/Options.cs
@@ -553,6 +553,15 @@ namespace MPF.Core.Data
             set { Settings["IncludeDebugProtectionInformation"] = value.ToString(); }
         }
 
+        /// <summary>
+        /// Remove drive letters from protection scan output
+        /// </summary>
+        public bool HideDriveLetters
+        {
+            get { return GetBooleanSetting(Settings, "HideDriveLetters", false); }
+            set { Settings["HideDriveLetters"] = value.ToString(); }
+        }
+
         #endregion
 
         #region Logging Options

--- a/MPF.Core/DumpEnvironment.cs
+++ b/MPF.Core/DumpEnvironment.cs
@@ -374,7 +374,7 @@ namespace MPF.Core
                 if (Options.ScanForProtection && Options.OutputSeparateProtectionFile)
                 {
                     resultProgress?.Report(Result.Success("Writing protection to !protectionInfo.txt..."));
-                    bool scanSuccess = InfoTool.WriteProtectionData(outputDirectory, filenameSuffix, submissionInfo);
+                    bool scanSuccess = InfoTool.WriteProtectionData(outputDirectory, filenameSuffix, submissionInfo, Options.HideDriveLetters);
                     if (scanSuccess)
                         resultProgress?.Report(Result.Success("Writing complete!"));
                     else

--- a/MPF.Core/InfoTool.cs
+++ b/MPF.Core/InfoTool.cs
@@ -1361,6 +1361,7 @@ namespace MPF.Core
         /// <param name="outputDirectory">Output folder to write to</param>
         /// <param name="filenameSuffix">Optional suffix to append to the filename</param>
         /// <param name="info">SubmissionInfo object containing the protection information</param>
+        /// <param name="hideDriveLetters">True if drive letters are to be removed from output, false otherwise</param>
         /// <returns>True on success, false on error</returns>
         public static bool WriteProtectionData(string? outputDirectory, string? filenameSuffix, SubmissionInfo? info, bool hideDriveLetters)
         {
@@ -1386,18 +1387,16 @@ namespace MPF.Core
                 List<string> sortedKeys = [.. info.CopyProtection.FullProtections.Keys.OrderBy(k => k)];
                 foreach (string key in sortedKeys)
                 {
-                    string scanPath;
+                    string scanPath = key;
                     if (hideDriveLetters)
-                        scanPath = key.Substring((Path.GetPathRoot(key) ?? String.Empty).Length);
-                    else
-                        scanPath = key;
+                        scanPath = Path.DirectorySeparatorChar + key.Substring((Path.GetPathRoot(key) ?? String.Empty).Length);
 
                     List<string>? scanResult = info.CopyProtection.FullProtections[key];
 
                     if (scanResult == null)
-                        sw.WriteLine($"{Path.DirectorySeparatorChar}{scanPath}: None");
+                        sw.WriteLine($"{scanPath}: None");
                     else
-                        sw.WriteLine($"{Path.DirectorySeparatorChar}{scanPath}: {string.Join(", ", [.. scanResult])}");
+                        sw.WriteLine($"{scanPath}: {string.Join(", ", [.. scanResult])}");
                 }
             }
             catch

--- a/MPF.Core/InfoTool.cs
+++ b/MPF.Core/InfoTool.cs
@@ -1362,7 +1362,7 @@ namespace MPF.Core
         /// <param name="filenameSuffix">Optional suffix to append to the filename</param>
         /// <param name="info">SubmissionInfo object containing the protection information</param>
         /// <returns>True on success, false on error</returns>
-        public static bool WriteProtectionData(string? outputDirectory, string? filenameSuffix, SubmissionInfo? info)
+        public static bool WriteProtectionData(string? outputDirectory, string? filenameSuffix, SubmissionInfo? info, bool hideDriveLetters)
         {
             // Check to see if the inputs are valid
             if (info?.CopyProtection?.FullProtections == null || !info.CopyProtection.FullProtections.Any())
@@ -1386,12 +1386,18 @@ namespace MPF.Core
                 List<string> sortedKeys = [.. info.CopyProtection.FullProtections.Keys.OrderBy(k => k)];
                 foreach (string key in sortedKeys)
                 {
-                    int pathRoot = (Path.GetPathRoot(key) ?? String.Empty).Length;
-                    List<string>? value = info.CopyProtection.FullProtections[key];
-                    if (value == null)
-                        sw.WriteLine($"{Path.DirectorySeparatorChar}{key.Substring(pathRoot)}: None");
+                    string scanPath;
+                    if (hideDriveLetters)
+                        scanPath = key.Substring((Path.GetPathRoot(key) ?? String.Empty).Length);
                     else
-                        sw.WriteLine($"{Path.DirectorySeparatorChar}{key.Substring(pathRoot)}: {string.Join(", ", [.. value])}");
+                        scanPath = key;
+
+                    List<string>? scanResult = info.CopyProtection.FullProtections[key];
+
+                    if (scanResult == null)
+                        sw.WriteLine($"{Path.DirectorySeparatorChar}{scanPath}: None");
+                    else
+                        sw.WriteLine($"{Path.DirectorySeparatorChar}{scanPath}: {string.Join(", ", [.. scanResult])}");
                 }
             }
             catch

--- a/MPF.Core/InfoTool.cs
+++ b/MPF.Core/InfoTool.cs
@@ -1384,10 +1384,11 @@ namespace MPF.Core
                 using var sw = new StreamWriter(File.Open(path, FileMode.Create, FileAccess.Write));
                 foreach (var kvp in info.CopyProtection.FullProtections)
                 {
+                    int pathRoot = (Path.GetPathRoot(kvp.Key) ?? String.Empty).Length;
                     if (kvp.Value == null)
-                        sw.WriteLine($"{kvp.Key}: None");
+                        sw.WriteLine($"{Path.DirectorySeparatorChar}{kvp.Key.Substring(pathRoot)}: None");
                     else
-                        sw.WriteLine($"{kvp.Key}: {string.Join(", ", [.. kvp.Value])}");
+                        sw.WriteLine($"{Path.DirectorySeparatorChar}{kvp.Key.Substring(pathRoot)}: {string.Join(", ", [.. kvp.Value])}");
                 }
             }
             catch

--- a/MPF.Core/InfoTool.cs
+++ b/MPF.Core/InfoTool.cs
@@ -1382,13 +1382,16 @@ namespace MPF.Core
                     path = Path.Combine(outputDirectory, $"!protectionInfo{filenameSuffix}.txt");
 
                 using var sw = new StreamWriter(File.Open(path, FileMode.Create, FileAccess.Write));
-                foreach (var kvp in info.CopyProtection.FullProtections)
+
+                List<string> sortedKeys = [.. info.CopyProtection.FullProtections.Keys.OrderBy(k => k)];
+                foreach (string key in sortedKeys)
                 {
-                    int pathRoot = (Path.GetPathRoot(kvp.Key) ?? String.Empty).Length;
-                    if (kvp.Value == null)
-                        sw.WriteLine($"{Path.DirectorySeparatorChar}{kvp.Key.Substring(pathRoot)}: None");
+                    int pathRoot = (Path.GetPathRoot(key) ?? String.Empty).Length;
+                    List<string>? value = info.CopyProtection.FullProtections[key];
+                    if (value == null)
+                        sw.WriteLine($"{Path.DirectorySeparatorChar}{key.Substring(pathRoot)}: None");
                     else
-                        sw.WriteLine($"{Path.DirectorySeparatorChar}{kvp.Key.Substring(pathRoot)}: {string.Join(", ", [.. kvp.Value])}");
+                        sw.WriteLine($"{Path.DirectorySeparatorChar}{key.Substring(pathRoot)}: {string.Join(", ", [.. value])}");
                 }
             }
             catch

--- a/MPF.Core/Utilities/OptionsLoader.cs
+++ b/MPF.Core/Utilities/OptionsLoader.cs
@@ -105,7 +105,7 @@ namespace MPF.Core.Utilities
             string? parsedPath = null;
 
             // These values require multiple parts to be active
-            bool scan = false, protectFile = false;
+            bool scan = false, protectFile = false, hideDriveLetters = false;
 
             // If we have no arguments, just return
             if (args == null || args.Length == 0)
@@ -174,6 +174,12 @@ namespace MPF.Core.Utilities
                     protectFile = true;
                 }
 
+                // Hide drive letters from scan output (requires --protect-file)
+                else if (args[startIndex].Equals("-g") || args[startIndex].Equals("--hide-drive-letters"))
+                {
+                    hideDriveLetters = true;
+                }
+
                 // Include seed info file
                 else if (args[startIndex].StartsWith("-l=") || args[startIndex].StartsWith("--load-seed="))
                 {
@@ -221,6 +227,7 @@ namespace MPF.Core.Utilities
             // Now deal with the complex options
             options.ScanForProtection = scan && !string.IsNullOrEmpty(parsedPath);
             options.OutputSeparateProtectionFile = scan && protectFile && !string.IsNullOrEmpty(parsedPath);
+            options.HideDriveLetters = hideDriveLetters && scan && protectFile && !string.IsNullOrEmpty(parsedPath);
 
             return (options, info, parsedPath, startIndex);
         }
@@ -238,6 +245,7 @@ namespace MPF.Core.Utilities
                 "-p, --path <drivepath>         Physical drive path for additional checks",
                 "-s, --scan                     Enable copy protection scan (requires --path)",
                 "-f, --protect-file             Output protection to separate file (requires --scan)",
+                "-g, --hide-drive-letters       Hide drive letters from scan output (requires --protect-file)",
                 "-l, --load-seed <path>         Load a seed submission JSON for user information",
                 "-x, --suffix                   Enable adding filename suffix",
                 "-j, --json                     Enable submission JSON output",

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -264,7 +264,7 @@
                         </GroupBox>
 
                         <GroupBox Margin="5,5,5,5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Header="Protection">
-                            <UniformGrid Columns="2" Rows="2">
+                            <UniformGrid Columns="2" Rows="3">
                                 <CheckBox VerticalAlignment="Center" Content="Enable Protection Scan"
                                           IsChecked="{Binding Options.ScanForProtection}"
                                           ToolTip="Enable automatic checking for copy protection on dumped media" Margin="0,4,0,0"
@@ -283,6 +283,11 @@
                                 <CheckBox VerticalAlignment="Center" Content="Include Debug Information"
                                           IsChecked="{Binding Options.IncludeDebugProtectionInformation}"
                                           ToolTip="Include debug information during protection scans" Margin="0,4"
+                                />
+
+                                <CheckBox VerticalAlignment="Center" Content="Hide Drive Letters"
+                                          IsChecked="{Binding Options.HideDriveLetters}"
+                                          ToolTip="Remove drive letters from protection scan output" Margin="0,4"
                                 />
                             </UniformGrid>
                         </GroupBox>


### PR DESCRIPTION
- Adds an option to (not by default) remove drive letter from !protectionInfo.txt, Windows only (Fixes #448)
- Sort keys alphabetically, makes !protectionInfo.txt deterministic