### PR TITLE
Use PSX/PS2 serial as filename when Volume Label not present

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -9,6 +9,7 @@
 - Support ringcode and PIC for triple/quad-layer (fuzz6001)
 - Cleanup !protectionInfo.txt (Deterous)
 - Update Redumper to build 311 (Deterous)
+- Use PSX/PS2 serial as filename when Volume Label not present (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -58,6 +58,8 @@ namespace MPF.Core.Data
 
         /// <summary>
         /// Media label as read by Windows, formatted to avoid odd outputs
+        /// If no volume label present, use PSX or PS2 serial if valid
+        /// Otherwise, use "track" as volume label
         /// </summary>
         public string? FormattedVolumeLabel
         {
@@ -66,10 +68,21 @@ namespace MPF.Core.Data
                 string? volumeLabel = Template.DiscNotDetected;
                 if (this.MarkedActive)
                 {
-                    if (string.IsNullOrEmpty(this.VolumeLabel))
-                        volumeLabel = "track";
-                    else
+                    if (!string.IsNullOrEmpty(this.VolumeLabel))
                         volumeLabel = this.VolumeLabel;
+                    else
+                    {
+                        RedumpSystem? system = this.GetRedumpSystem(null);
+                        if (system == RedumpSystem.SonyPlayStation || system == RedumpSystem.SonyPlayStation2)
+                        {
+                            InfoTool.GetPlayStationExecutableInfo(this.Name, out string? serial, out _, out _);
+                            volumeLabel = serial ?? "track";
+                        }
+                        else
+                        {
+                            volumeLabel = "track";
+                        }
+                    }
                 }
 
                 foreach (char c in Path.GetInvalidFileNameChars())

--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -66,22 +66,25 @@ namespace MPF.Core.Data
             get
             {
                 string? volumeLabel = Template.DiscNotDetected;
-                if (this.MarkedActive)
+                if (!this.MarkedActive)
+                    return volumeLabel;
+
+                if (!string.IsNullOrEmpty(this.VolumeLabel))
+                    volumeLabel = this.VolumeLabel;
+                else
                 {
-                    if (!string.IsNullOrEmpty(this.VolumeLabel))
-                        volumeLabel = this.VolumeLabel;
-                    else
+                    // No Volume Label found, fallback to something sensible
+                    switch (this.GetRedumpSystem(null))
                     {
-                        RedumpSystem? system = this.GetRedumpSystem(null);
-                        if (system == RedumpSystem.SonyPlayStation || system == RedumpSystem.SonyPlayStation2)
-                        {
+                        case RedumpSystem.SonyPlayStation:
+                        case RedumpSystem.SonyPlayStation2:
                             InfoTool.GetPlayStationExecutableInfo(this.Name, out string? serial, out _, out _);
                             volumeLabel = serial ?? "track";
-                        }
-                        else
-                        {
+                            break;
+                        
+                        default:
                             volumeLabel = "track";
-                        }
+                            break;
                     }
                 }
 


### PR DESCRIPTION
If no volume label is found, and the current system is PSX or PS2, use the PlayStation serial as the volume label instead of "track"
I initially tried for PS3/PS4/PS5 as well, but those systems have a default volume label ("PS3VOLUME" etc), so there is no point doing this for those systems.

Fixes #494 