### PR TITLE
Allow variables in output path

### DIFF
--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -70,7 +70,9 @@ namespace MPF.Core.Data
                     return volumeLabel;
 
                 if (!string.IsNullOrEmpty(this.VolumeLabel))
+                {
                     volumeLabel = this.VolumeLabel;
+                }
                 else
                 {
                     // No Volume Label found, fallback to something sensible

--- a/MPF.Core/InfoTool.cs
+++ b/MPF.Core/InfoTool.cs
@@ -1876,8 +1876,10 @@ namespace MPF.Core
                 if (string.IsNullOrEmpty(path))
                     return string.Empty;
 
-                // Remove quotes from path
+                // Remove quotes and angle brackets from path
                 path = path!.Replace("\"", string.Empty);
+                path = path!.Replace("<", string.Empty);
+                path = path!.Replace(">", string.Empty);
 
                 // Try getting the combined path and returning that directly
                 string fullPath = getFullPath ? Path.GetFullPath(path) : path;

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -169,21 +169,21 @@ namespace MPF.Core.UI.ViewModels
         {
             get
             {
-                string system_long = this._currentSystem.LongName() ?? "Unknown System";
-                string system_short = this._currentSystem.ShortName() ?? "unknown";
-                string media_long = this._currentMediaType.LongName() ?? "Unknown Media";
+                string systemLong = this._currentSystem.LongName() ?? "Unknown System";
+                string systemShort = this._currentSystem.ShortName() ?? "unknown";
+                string mediaLong = this._currentMediaType.LongName() ?? "Unknown Media";
                 string program = this._currentProgram.ToString() ?? "Unknown Program";
-                string program_short = program == "DiscImageCreator" ? "DIC" : program;
+                string programShort = program == "DiscImageCreator" ? "DIC" : program;
                 string label = this._currentDrive?.VolumeLabel ?? "track";
                 string date = DateTime.Today.ToString("yyyyMMdd");
                 string datetime = DateTime.Now.ToString("yyyyMMdd-HHmmss");
 
                 return _outputPath
-                    .Replace("<SYSTEM>", system_long)
-                    .Replace("<SYS>", system_short)
-                    .Replace("<MEDIA>", media_long)
+                    .Replace("<SYSTEM>", systemLong)
+                    .Replace("<SYS>", systemShort)
+                    .Replace("<MEDIA>", mediaLong)
                     .Replace("<PROGRAM>", program)
-                    .Replace("<PROG>", program_short)
+                    .Replace("<PROG>", programShort)
                     .Replace("<LABEL>", label)
                     .Replace("<DATE>", date)
                     .Replace("<DATETIME>", datetime);

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -148,7 +148,7 @@ namespace MPF.Core.UI.ViewModels
 
         /// <summary>
         /// Currently provided output path
-        /// May not a valid path
+        /// Not guaranteed to be a valid path
         /// </summary>
         public string OutputPath
         {
@@ -163,7 +163,7 @@ namespace MPF.Core.UI.ViewModels
 
         /// <summary>
         /// Currently provided output path, with < > variables evaluated
-        /// May not be a valid path
+        /// Not guaranteed to be a valid path
         /// </summary>
         public string OutputPathEvaluated
         {

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -170,23 +170,39 @@ namespace MPF.Core.UI.ViewModels
             get
             {
                 string systemLong = this._currentSystem.LongName() ?? "Unknown System";
+                if (String.IsNullOrEmpty(systemLong))
+                    systemLong = "Unknown System";
                 string systemShort = this._currentSystem.ShortName() ?? "unknown";
+                if (String.IsNullOrEmpty(systemShort))
+                    systemShort = "unknown";
                 string mediaLong = this._currentMediaType.LongName() ?? "Unknown Media";
+                if (String.IsNullOrEmpty(mediaLong))
+                    mediaLong = "Unknown Media";
                 string program = this._currentProgram.ToString() ?? "Unknown Program";
+                if (String.IsNullOrEmpty(program))
+                    program = "Unknown Program";
                 string programShort = program == "DiscImageCreator" ? "DIC" : program;
-                string label = this._currentDrive?.VolumeLabel ?? "track";
+                if (String.IsNullOrEmpty(programShort))
+                    programShort = "Unknown Program";
+                string label = this._currentDrive?.FormattedVolumeLabel ?? "track";
+                if (String.IsNullOrEmpty(label))
+                    label = "track";
                 string date = DateTime.Today.ToString("yyyyMMdd");
+                if (String.IsNullOrEmpty(date))
+                    date = "UNKNOWN";
                 string datetime = DateTime.Now.ToString("yyyyMMdd-HHmmss");
+                if (String.IsNullOrEmpty(datetime))
+                    datetime = "UNKNOWN";
 
                 return _outputPath
-                    .Replace("<SYSTEM>", systemLong)
-                    .Replace("<SYS>", systemShort)
-                    .Replace("<MEDIA>", mediaLong)
-                    .Replace("<PROGRAM>", program)
-                    .Replace("<PROG>", programShort)
-                    .Replace("<LABEL>", label)
-                    .Replace("<DATE>", date)
-                    .Replace("<DATETIME>", datetime);
+                    .Replace("%SYSTEM%", systemLong)
+                    .Replace("%SYS%", systemShort)
+                    .Replace("%MEDIA%", mediaLong)
+                    .Replace("%PROGRAM%", program)
+                    .Replace("%PROG%", programShort)
+                    .Replace("%LABEL%", label)
+                    .Replace("%DATE%", date)
+                    .Replace("%DATETIME%", datetime);
             }
         }
 

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -162,51 +162,6 @@ namespace MPF.Core.UI.ViewModels
         private string _outputPath;
 
         /// <summary>
-        /// Currently provided output path, with < > variables evaluated
-        /// Not guaranteed to be a valid path
-        /// </summary>
-        public string OutputPathEvaluated
-        {
-            get
-            {
-                string systemLong = this._currentSystem.LongName() ?? "Unknown System";
-                if (String.IsNullOrEmpty(systemLong))
-                    systemLong = "Unknown System";
-                string systemShort = this._currentSystem.ShortName() ?? "unknown";
-                if (String.IsNullOrEmpty(systemShort))
-                    systemShort = "unknown";
-                string mediaLong = this._currentMediaType.LongName() ?? "Unknown Media";
-                if (String.IsNullOrEmpty(mediaLong))
-                    mediaLong = "Unknown Media";
-                string program = this._currentProgram.ToString() ?? "Unknown Program";
-                if (String.IsNullOrEmpty(program))
-                    program = "Unknown Program";
-                string programShort = program == "DiscImageCreator" ? "DIC" : program;
-                if (String.IsNullOrEmpty(programShort))
-                    programShort = "Unknown Program";
-                string label = this._currentDrive?.FormattedVolumeLabel ?? "track";
-                if (String.IsNullOrEmpty(label))
-                    label = "track";
-                string date = DateTime.Today.ToString("yyyyMMdd");
-                if (String.IsNullOrEmpty(date))
-                    date = "UNKNOWN";
-                string datetime = DateTime.Now.ToString("yyyyMMdd-HHmmss");
-                if (String.IsNullOrEmpty(datetime))
-                    datetime = "UNKNOWN";
-
-                return _outputPath
-                    .Replace("%SYSTEM%", systemLong)
-                    .Replace("%SYS%", systemShort)
-                    .Replace("%MEDIA%", mediaLong)
-                    .Replace("%PROGRAM%", program)
-                    .Replace("%PROG%", programShort)
-                    .Replace("%LABEL%", label)
-                    .Replace("%DATE%", date)
-                    .Replace("%DATETIME%", datetime);
-            }
-        }
-
-        /// <summary>
         /// Indicates the status of the output path text box
         /// </summary>
         public bool OutputPathTextBoxEnabled
@@ -1236,7 +1191,7 @@ namespace MPF.Core.UI.ViewModels
         {
             return new DumpEnvironment(
                 this.Options,
-                this.OutputPathEvaluated,
+                EvaluateOutputPath(this.OutputPath),
                 this.CurrentDrive,
                 this.CurrentSystem,
                 this.CurrentMediaType,
@@ -1343,6 +1298,49 @@ namespace MPF.Core.UI.ViewModels
                 if (generated != null)
                     this.Parameters = generated;
             }
+        }
+
+        /// <summary>
+        /// Replaces %-delimited variables inside a path string with their values
+        /// </summary>
+        /// <param name="outputPath">Path to be evaluated</param>
+        /// <returns>String with %-delimited variables evaluated</returns>
+        public string EvaluateOutputPath(string outputPath)
+        {
+            string systemLong = this._currentSystem.LongName() ?? "Unknown System";
+            if (string.IsNullOrEmpty(systemLong))
+                systemLong = "Unknown System";
+            string systemShort = this._currentSystem.ShortName() ?? "unknown";
+            if (string.IsNullOrEmpty(systemShort))
+                systemShort = "unknown";
+            string mediaLong = this._currentMediaType.LongName() ?? "Unknown Media";
+            if (string.IsNullOrEmpty(mediaLong))
+                mediaLong = "Unknown Media";
+            string program = this._currentProgram.ToString() ?? "Unknown Program";
+            if (string.IsNullOrEmpty(program))
+                program = "Unknown Program";
+            string programShort = program == "DiscImageCreator" ? "DIC" : program;
+            if (string.IsNullOrEmpty(programShort))
+                programShort = "Unknown Program";
+            string label = this._currentDrive?.FormattedVolumeLabel ?? "track";
+            if (string.IsNullOrEmpty(label))
+                label = "track";
+            string date = DateTime.Today.ToString("yyyyMMdd");
+            if (string.IsNullOrEmpty(date))
+                date = "UNKNOWN";
+            string datetime = DateTime.Now.ToString("yyyyMMdd-HHmmss");
+            if (string.IsNullOrEmpty(datetime))
+                datetime = "UNKNOWN";
+
+            return outputPath
+                .Replace("%SYSTEM%", systemLong)
+                .Replace("%SYS%", systemShort)
+                .Replace("%MEDIA%", mediaLong)
+                .Replace("%PROGRAM%", program)
+                .Replace("%PROG%", programShort)
+                .Replace("%LABEL%", label)
+                .Replace("%DATE%", date)
+                .Replace("%DATETIME%", datetime);
         }
 
         /// <summary>

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -148,6 +148,7 @@ namespace MPF.Core.UI.ViewModels
 
         /// <summary>
         /// Currently provided output path
+        /// May not a valid path
         /// </summary>
         public string OutputPath
         {
@@ -159,6 +160,35 @@ namespace MPF.Core.UI.ViewModels
             }
         }
         private string _outputPath;
+
+        /// <summary>
+        /// Currently provided output path, with < > variables evaluated
+        /// May not be a valid path
+        /// </summary>
+        public string OutputPathEvaluated
+        {
+            get
+            {
+                string system_long = this._currentSystem.LongName() ?? "Unknown System";
+                string system_short = this._currentSystem.ShortName() ?? "unknown";
+                string media_long = this._currentMediaType.LongName() ?? "Unknown Media";
+                string program = this._currentProgram.ToString() ?? "Unknown Program";
+                string program_short = program == "DiscImageCreator" ? "DIC" : program;
+                string label = this._currentDrive?.VolumeLabel ?? "track";
+                string date = DateTime.Today.ToString("yyyyMMdd");
+                string datetime = DateTime.Now.ToString("yyyyMMdd-HHmmss");
+
+                return _outputPath
+                    .Replace("<SYSTEM>", system_long)
+                    .Replace("<SYS>", system_short)
+                    .Replace("<MEDIA>", media_long)
+                    .Replace("<PROGRAM>", program)
+                    .Replace("<PROG>", program_short)
+                    .Replace("<LABEL>", label)
+                    .Replace("<DATE>", date)
+                    .Replace("<DATETIME>", datetime);
+            }
+        }
 
         /// <summary>
         /// Indicates the status of the output path text box
@@ -1190,7 +1220,7 @@ namespace MPF.Core.UI.ViewModels
         {
             return new DumpEnvironment(
                 this.Options,
-                this.OutputPath,
+                this.OutputPathEvaluated,
                 this.CurrentDrive,
                 this.CurrentSystem,
                 this.CurrentMediaType,

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -182,7 +182,7 @@
                         <Label Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="Default Output Path" />
                         <TextBox x:Name="DefaultOutputPathTextBox" Grid.Row="4" Grid.Column="1" Height="22" HorizontalAlignment="Stretch"
                                  Text="{Binding Options.DefaultOutputPath}" VerticalContentAlignment="Center" 
-                                 ToolTip="Variables allowed:&#x0a;  &lt;SYSTEM&gt;&#9;(System name, long)&#x0a;  &lt;SYS&gt;&#9;&#9;(System name, short)&#x0a;  &lt;MEDIA&gt;&#9;(Media type)&#x0a;  &lt;PROGRAM&gt;&#9;(Program name, long)&#x0a;  &lt;PROG&gt;&#9;(Program name, short)&#x0a;  &lt;LABEL&gt;&#9;(Volume label)&#x0a;  &lt;DATE&gt;&#9;(Current date)&#x0a;  &lt;DATETIME&gt;&#9;(Current date and time)"/>
+                                 ToolTip="Variables allowed:&#x0a;  &#37;SYSTEM&#37;&#9;(System name, long)&#x0a;  &#37;SYS&#37;&#9;&#9;(System name, short)&#x0a;  &#37;MEDIA&#37;&#9;(Media type)&#x0a;  &#37;PROGRAM&#37;&#9;(Program name, long)&#x0a;  &#37;PROG&#37;&#9;(Program name, short)&#x0a;  &#37;LABEL&#37;&#9;(Volume label)&#x0a;  &#37;DATE&#37;&#9;(Current date)&#x0a;  &#37;DATETIME&#37;&#9;(Current date and time)"/>
                         <Button x:Name="DefaultOutputPathButton" Grid.Row="4" Grid.Column="2" Height="22" Width="22" Content="..."
                                 Style="{DynamicResource CustomButtonStyle}" />
                     </Grid>

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -182,7 +182,7 @@
                         <Label Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="Default Output Path" />
                         <TextBox x:Name="DefaultOutputPathTextBox" Grid.Row="4" Grid.Column="1" Height="22" HorizontalAlignment="Stretch"
                                  Text="{Binding Options.DefaultOutputPath}" VerticalContentAlignment="Center" 
-                                 ToolTip="Variables allowed:&#x0a;&lt;SYSTEM&gt; (System name, long)&#x0a;&lt;SYS&gt; (System name, short)&#x0a;&lt;MEDIA&gt; (Media type)&#x0a;&lt;PROGRAM&gt; (Program name, long)&#x0a;&lt;PROG&gt; (Program name, short)&#x0a;&lt;LABEL&gt; (Volume label)&#x0a;&lt;DATE&gt; (Current date)&#x0a;&lt;DATETIME&gt; (Current date and time)"/>
+                                 ToolTip="Variables allowed:&#x0a;  &lt;SYSTEM&gt;&#9;(System name, long)&#x0a;  &lt;SYS&gt;&#9;&#9;(System name, short)&#x0a;  &lt;MEDIA&gt;&#9;(Media type)&#x0a;  &lt;PROGRAM&gt;&#9;(Program name, long)&#x0a;  &lt;PROG&gt;&#9;(Program name, short)&#x0a;  &lt;LABEL&gt;&#9;(Volume label)&#x0a;  &lt;DATE&gt;&#9;(Current date)&#x0a;  &lt;DATETIME&gt;&#9;(Current date and time)"/>
                         <Button x:Name="DefaultOutputPathButton" Grid.Row="4" Grid.Column="2" Height="22" Width="22" Content="..."
                                 Style="{DynamicResource CustomButtonStyle}" />
                     </Grid>

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -181,7 +181,8 @@
 
                         <Label Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="Default Output Path" />
                         <TextBox x:Name="DefaultOutputPathTextBox" Grid.Row="4" Grid.Column="1" Height="22" HorizontalAlignment="Stretch"
-                                 Text="{Binding Options.DefaultOutputPath}" VerticalContentAlignment="Center" />
+                                 Text="{Binding Options.DefaultOutputPath}" VerticalContentAlignment="Center" 
+                                 ToolTip="Variables allowed:&#x0a;&lt;SYSTEM&gt; (System name, long)&#x0a;&lt;SYS&gt; (System name, short)&#x0a;&lt;MEDIA&gt; (Media type)&#x0a;&lt;PROGRAM&gt; (Program name, long)&#x0a;&lt;PROG&gt; (Program name, short)&#x0a;&lt;LABEL&gt; (Volume label)&#x0a;&lt;DATE&gt; (Current date)&#x0a;&lt;DATETIME&gt; (Current date and time)"/>
                         <Button x:Name="DefaultOutputPathButton" Grid.Row="4" Grid.Column="2" Height="22" Width="22" Content="..."
                                 Style="{DynamicResource CustomButtonStyle}" />
                     </Grid>


### PR DESCRIPTION
Attempts to provide a general solution/fix for #458 

Type the following keywords into output path or default output path textboxes to use variables:
`%SYSTEM%` = Long name for system
`%SYS%` = Short name for system
`%MEDIA%` = Long name for media type
`%PROGRAM%` = Long name for dumping program
`%PROG%` = Short name for dumping program (currently only DiscImageCreator -> DIC)
`%LABEL%` = Volume Label
`%DATE%` = "YYYYMMDD" current date
`%DATETIME%` = "YYYYMMDD-HHMMSS" current datetime

For now, these are not documented anywhere, but are provided for advanced users.