### PR TITLE
Check for presence of complete dump from other programs

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -10,6 +10,8 @@
 - Cleanup !protectionInfo.txt (Deterous)
 - Update Redumper to build 311 (Deterous)
 - Use PSX/PS2 serial as filename when Volume Label not present (Deterous)
+- Allow variables in output path (Deterous)
+- Check if a dump from another program is present in folder (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -11,7 +11,7 @@
 - Update Redumper to build 311 (Deterous)
 - Use PSX/PS2 serial as filename when Volume Label not present (Deterous)
 - Allow variables in output path (Deterous)
-- Check if a dump from another program is present in folder (Deterous)
+- Check for presence of complete dump from other programs (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -50,7 +50,7 @@ namespace MPF.Core.UI.ViewModels
         /// </summary>
         /// <remarks>
         /// T1 - Title to display to the user
-        /// T1 - Message to display to the user
+        /// T2 - Message to display to the user
         /// T3 - Number of default options to display
         /// T4 - true for inquiry, false otherwise
         /// TResult - true for positive, false for negative, null for neutral
@@ -1767,6 +1767,57 @@ namespace MPF.Core.UI.ViewModels
             if (foundFiles && _displayUserMessage != null)
             {
                 bool? mbresult = _displayUserMessage("Overwrite?", "A complete dump already exists! Are you sure you want to overwrite?", 2, true);
+                if (mbresult != true)
+                {
+                    LogLn("Dumping aborted!");
+                    return false;
+                }
+            }
+
+            // If a complete dump exists from a different program
+            InternalProgram? programFound = null;
+            if (programFound == null && _environment.InternalProgram != InternalProgram.Aaru)
+            {
+                Modules.Aaru.Parameters parameters = new("")
+                {
+                    Type = _environment.Type,
+                    System = _environment.System
+                };
+                (bool foundOtherFiles, List<string> _) = parameters.FoundAllFiles(outputDirectory, outputFilename, true);
+                if (foundOtherFiles)
+                {
+                    programFound = InternalProgram.Aaru;
+                }
+            }
+            if (programFound == null && _environment.InternalProgram != InternalProgram.DiscImageCreator)
+            {
+                Modules.DiscImageCreator.Parameters parameters = new("")
+                {
+                    Type = _environment.Type,
+                    System = _environment.System
+                };
+                (bool foundOtherFiles, List<string> _) = parameters.FoundAllFiles(outputDirectory, outputFilename, true);
+                if (foundOtherFiles)
+                {
+                    programFound = InternalProgram.DiscImageCreator;
+                }
+            }
+            if (programFound == null && _environment.InternalProgram != InternalProgram.Redumper)
+            {
+                Modules.Redumper.Parameters parameters = new("")
+                {
+                    Type = _environment.Type,
+                    System = _environment.System
+                };
+                (bool foundOtherFiles, List<string> _) = parameters.FoundAllFiles(outputDirectory, outputFilename, true);
+                if (foundOtherFiles)
+                {
+                    programFound = InternalProgram.Redumper;
+                }
+            }
+            if (programFound != null && _displayUserMessage != null)
+            {
+                bool? mbresult = _displayUserMessage("Overwrite?", $"A complete dump from {programFound} already exists! Dumping here may cause issues. Are you sure you want to overwrite?", 2, true);
                 if (mbresult != true)
                 {
                     LogLn("Dumping aborted!");

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -1783,11 +1783,9 @@ namespace MPF.Core.UI.ViewModels
                     Type = _environment.Type,
                     System = _environment.System
                 };
-                (bool foundOtherFiles, List<string> _) = parameters.FoundAllFiles(outputDirectory, outputFilename, true);
+                (bool foundOtherFiles, _) = parameters.FoundAllFiles(outputDirectory, outputFilename, true);
                 if (foundOtherFiles)
-                {
                     programFound = InternalProgram.Aaru;
-                }
             }
             if (programFound == null && _environment.InternalProgram != InternalProgram.DiscImageCreator)
             {
@@ -1796,11 +1794,9 @@ namespace MPF.Core.UI.ViewModels
                     Type = _environment.Type,
                     System = _environment.System
                 };
-                (bool foundOtherFiles, List<string> _) = parameters.FoundAllFiles(outputDirectory, outputFilename, true);
+                (bool foundOtherFiles, _) = parameters.FoundAllFiles(outputDirectory, outputFilename, true);
                 if (foundOtherFiles)
-                {
                     programFound = InternalProgram.DiscImageCreator;
-                }
             }
             if (programFound == null && _environment.InternalProgram != InternalProgram.Redumper)
             {
@@ -1809,11 +1805,9 @@ namespace MPF.Core.UI.ViewModels
                     Type = _environment.Type,
                     System = _environment.System
                 };
-                (bool foundOtherFiles, List<string> _) = parameters.FoundAllFiles(outputDirectory, outputFilename, true);
+                (bool foundOtherFiles, _) = parameters.FoundAllFiles(outputDirectory, outputFilename, true);
                 if (foundOtherFiles)
-                {
                     programFound = InternalProgram.Redumper;
-                }
             }
             if (programFound != null && _displayUserMessage != null)
             {


### PR DESCRIPTION
Checks for presence of a complete dump from other programs before beginning a new dump, to prevent overwriting files.
Fixes #595 