### PR TITLE
Retrieve volume label from logs

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -12,6 +12,7 @@
 - Use PSX/PS2 serial as filename when Volume Label not present (Deterous)
 - Allow variables in output path (Deterous)
 - Check for presence of complete dump from other programs (Deterous)
+- Retrieve volume label from logs (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -277,7 +277,7 @@ namespace MPF.Core.Data
                 return RedumpSystem.IBMPCcompatible;
 
             // Check volume labels first
-            RedumpSystem? systemFromLabel = GetRedumpSystemFromVolumeLabel();
+            RedumpSystem? systemFromLabel = GetRedumpSystemFromVolumeLabel(this.VolumeLabel);
             if (systemFromLabel != null)
                 return systemFromLabel;
 
@@ -512,48 +512,48 @@ namespace MPF.Core.Data
         /// Get the current system from the drive volume label
         /// </summary>
         /// <returns>The system based on volume label, null if none detected</returns>
-        public RedumpSystem? GetRedumpSystemFromVolumeLabel()
+        public static RedumpSystem? GetRedumpSystemFromVolumeLabel(string? volumeLabel)
         {
             // If the volume label is empty, we can't do anything
-            if (string.IsNullOrEmpty(this.VolumeLabel))
+            if (string.IsNullOrEmpty(volumeLabel))
                 return null;
 
             // Audio CD
-            if (this.VolumeLabel!.Equals("Audio CD", StringComparison.OrdinalIgnoreCase))
+            if (volumeLabel!.Equals("Audio CD", StringComparison.OrdinalIgnoreCase))
                 return RedumpSystem.AudioCD;
 
             // Microsoft Xbox
-            if (this.VolumeLabel.Equals("SEP13011042", StringComparison.OrdinalIgnoreCase))
+            if (volumeLabel.Equals("SEP13011042", StringComparison.OrdinalIgnoreCase))
                 return RedumpSystem.MicrosoftXbox;
-            else if (this.VolumeLabel.Equals("SEP13011042072", StringComparison.OrdinalIgnoreCase))
+            else if (volumeLabel.Equals("SEP13011042072", StringComparison.OrdinalIgnoreCase))
                 return RedumpSystem.MicrosoftXbox;
 
             // Microsoft Xbox 360
-            if (this.VolumeLabel.Equals("XBOX360", StringComparison.OrdinalIgnoreCase))
+            if (volumeLabel.Equals("XBOX360", StringComparison.OrdinalIgnoreCase))
                 return RedumpSystem.MicrosoftXbox360;
-            else if (this.VolumeLabel.Equals("XGD2DVD_NTSC", StringComparison.OrdinalIgnoreCase))
+            else if (volumeLabel.Equals("XGD2DVD_NTSC", StringComparison.OrdinalIgnoreCase))
                 return RedumpSystem.MicrosoftXbox360;
 
             // Microsoft Xbox 360 - Too overly broad even if a lot of discs use this
-            //if (this.VolumeLabel.Equals("CD_ROM", StringComparison.OrdinalIgnoreCase))
+            //if (volumeLabel.Equals("CD_ROM", StringComparison.OrdinalIgnoreCase))
             //    return RedumpSystem.MicrosoftXbox360; // Also for Xbox One?
-            //if (this.VolumeLabel.Equals("DVD_ROM", StringComparison.OrdinalIgnoreCase))
+            //if (volumeLabel.Equals("DVD_ROM", StringComparison.OrdinalIgnoreCase))
             //    return RedumpSystem.MicrosoftXbox360;
 
             // Sega Mega-CD / Sega-CD
-            if (this.VolumeLabel.Equals("Sega_CD", StringComparison.OrdinalIgnoreCase))
+            if (volumeLabel.Equals("Sega_CD", StringComparison.OrdinalIgnoreCase))
                 return RedumpSystem.SegaMegaCDSegaCD;
 
             // Sony PlayStation 3
-            if (this.VolumeLabel.Equals("PS3VOLUME", StringComparison.OrdinalIgnoreCase))
+            if (volumeLabel.Equals("PS3VOLUME", StringComparison.OrdinalIgnoreCase))
                 return RedumpSystem.SonyPlayStation3;
 
             // Sony PlayStation 4
-            if (this.VolumeLabel.Equals("PS4VOLUME", StringComparison.OrdinalIgnoreCase))
+            if (volumeLabel.Equals("PS4VOLUME", StringComparison.OrdinalIgnoreCase))
                 return RedumpSystem.SonyPlayStation4;
 
             // Sony PlayStation 5
-            if (this.VolumeLabel.Equals("PS5VOLUME", StringComparison.OrdinalIgnoreCase))
+            if (volumeLabel.Equals("PS5VOLUME", StringComparison.OrdinalIgnoreCase))
                 return RedumpSystem.SonyPlayStation5;
 
             return null;

--- a/MPF.Core/Modules/BaseParameters.cs
+++ b/MPF.Core/Modules/BaseParameters.cs
@@ -74,6 +74,11 @@ namespace MPF.Core.Modules
         /// </summary>
         private Process? process;
 
+        /// <summary>
+        /// All found volume labels and their corresponding file systems
+        /// </summary>
+        public Dictionary<string, List<string>>? VolumeLabels;
+
         #endregion
 
         #region Virtual Dumping Information

--- a/MPF.Core/Modules/DiscImageCreator/Parameters.cs
+++ b/MPF.Core/Modules/DiscImageCreator/Parameters.cs
@@ -2773,6 +2773,19 @@ namespace MPF.Core.Modules.DiscImageCreator
                     else if (line.StartsWith("Volume Identifier: "))
                     {
                         label = line.Substring("Volume Identifier: ".Length);
+
+                        // Remove leading non-printable character (unsure why DIC outputs this)
+                        if (Convert.ToUInt32(label[0]) == 0x7F || Convert.ToUInt32(label[0]) < 0x20)
+                            label = label.Substring(1);
+
+                        // Skip if label is blank
+                        if (label == null || label.Length <= 0)
+                        {
+                            volType = "UNKNOWN";
+                            line = sr.ReadLine();
+                            continue;
+                        }
+
                         if (volLabels.ContainsKey(label))
                             volLabels[label].Add(volType);
                         else

--- a/MPF.Core/Modules/DiscImageCreator/Parameters.cs
+++ b/MPF.Core/Modules/DiscImageCreator/Parameters.cs
@@ -409,6 +409,10 @@ namespace MPF.Core.Modules.DiscImageCreator
             // Fill in the hash data
             info.TracksAndWriteOffsets!.ClrMameProData = InfoTool.GenerateDatfile(datafile);
 
+            // Fill in the volume labels
+            if (GetVolumeLabels($"{basePath}_volDesc.txt", out var volLabels))
+                VolumeLabels = volLabels;
+
             // Extract info based generically on MediaType
             switch (this.Type)
             {
@@ -2718,6 +2722,76 @@ namespace MPF.Core.Modules.DiscImageCreator
             {
                 // We don't care what the exception is right now
                 discTypeOrBookType = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Get all Volume Identifiers
+        /// </summary>
+        /// <param name="volDesc">_volDesc.txt file location</param>
+        /// <returns>Volume labels (by type), or null if none present</returns>
+        private static bool GetVolumeLabels(string volDesc, out Dictionary<string, List<string>> volLabels)
+        {
+            // If the file doesn't exist, can't get the volume labels
+            volLabels = [];
+            if (!File.Exists(volDesc))
+                return false;
+
+            try
+            {
+                using var sr = File.OpenText(volDesc);
+                var line = sr.ReadLine();
+
+                string volType = "UNKNOWN";
+                string label;
+                while (line != null)
+                {
+                    // Trim the line for later use
+                    line = line.Trim();
+                    
+                    // ISO9660 and extensions section
+                    if (line.StartsWith("Volume Descriptor Type: "))
+                    {
+                        Int32.TryParse(line.Substring("Volume Descriptor Type: ".Length), out int volTypeInt);
+                        volType = volTypeInt switch
+                        {
+                            // 0 => "Boot Record" // Should not not contain a Volume Identifier
+                            1 => "ISO", // ISO9660
+                            2 => "Joliet",
+                            // 3 => "Volume Partition Descriptor" // Should not not contain a Volume Identifier
+                            // 255 => "???" // Should not not contain a Volume Identifier
+                            _ => "UNKNOWN" // Should not contain a Volume Identifier
+                        };
+                    }
+                    // UDF section
+                    else if (line.StartsWith("Primary Volume Descriptor Number:"))
+                    {
+                        volType = "UDF";
+                    }
+                    // Identifier
+                    else if (line.StartsWith("Volume Identifier: "))
+                    {
+                        label = line.Substring("Volume Identifier: ".Length);
+                        if (volLabels.ContainsKey(label))
+                            volLabels[label].Add(volType);
+                        else
+                            volLabels.Add(label, [volType]);
+
+                        // Reset volume type
+                        volType = "UNKNOWN";
+                    }
+
+                    line = sr.ReadLine();
+                }
+
+                // Return true if a volume label was found
+                return volLabels.Count > 0;
+            }
+            catch
+            {
+                // We don't care what the exception is right now
+                volLabels = [];
                 return false;
             }
         }

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -1522,6 +1522,11 @@ namespace MPF.Core.Modules.Redumper
                     if (line.StartsWith("volume identifier: "))
                     {
                         string label = line.Substring("volume identifier: ".Length);
+
+                        // Skip if label is blank
+                        if (label == null || label.Length <= 0)
+                            break;
+
                         if (volLabels.ContainsKey(label))
                             volLabels[label].Add("ISO");
                         else

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection.Emit;
 using System.Text.RegularExpressions;
 using MPF.Core.Converters;
 using MPF.Core.Data;

--- a/MPF.Core/SubmissionInfoTool.cs
+++ b/MPF.Core/SubmissionInfoTool.cs
@@ -682,13 +682,12 @@ namespace MPF.Core
         /// <returns>Formatted string of volume labels and their filesystems</returns>
         private static string? FormatVolumeLabels(string? driveLabel, Dictionary<string, List<string>>? labels)
         {
-
             // Must have at least one label to format
-            if (driveLabel == null && (labels == null || labels.Count <= 0))
+            if (driveLabel == null && (labels == null || labels.Count == 0))
                 return null;
 
             // If no labels given, use drive label
-            if (labels == null || labels.Count <= 0)
+            if (labels == null || labels.Count == 0)
             {
                 // Ignore common volume labels
                 if (Drive.GetRedumpSystemFromVolumeLabel(driveLabel) != null)
@@ -698,7 +697,7 @@ namespace MPF.Core
             }
 
             // If only one label, don't mention fs
-            string firstLabel = labels.FirstOrDefault().Key;
+            string firstLabel = labels.First().Key;
             if (labels.Count == 1 && (firstLabel == driveLabel || driveLabel == null))
             {
                 // Ignore common volume labels
@@ -724,7 +723,7 @@ namespace MPF.Core
             }
 
             // Print each label separated by a comma and a space
-            if (volLabels == null)
+            if (volLabels.Count == 0)
                 return null;
 
             return string.Join(", ", [.. volLabels]);

--- a/MPF.Core/SubmissionInfoTool.cs
+++ b/MPF.Core/SubmissionInfoTool.cs
@@ -712,7 +712,7 @@ namespace MPF.Core
             List<string> volLabels = [];
             
             // Begin formatted output with the label from Windows, if it is unique and not a common volume label
-            if (driveLabel != null && !labels.TryGetValue(driveLabel, out List<string>? value) && Drive.GetRedumpSystemFromVolumeLabel(driveLabel) != null)
+            if (driveLabel != null && !labels.TryGetValue(driveLabel, out List<string>? value) && Drive.GetRedumpSystemFromVolumeLabel(driveLabel) == null)
                 volLabels.Add(driveLabel);
 
             // Add remaining labels with their corresponding filesystems

--- a/MPF.Core/SubmissionInfoTool.cs
+++ b/MPF.Core/SubmissionInfoTool.cs
@@ -110,8 +110,9 @@ namespace MPF.Core
                 info.TracksAndWriteOffsets.ClrMameProData = null;
 
             // Add the volume label to comments, if possible or necessary
-            if (drive?.VolumeLabel != null && drive.GetRedumpSystemFromVolumeLabel() == null)
-                info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.VolumeLabel] = drive.VolumeLabel;
+            string? volLabels = FormatVolumeLabels(drive?.VolumeLabel, parameters?.VolumeLabels);
+            if (volLabels != null)
+                info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.VolumeLabel] = volLabels;
 
             // Extract info based generically on MediaType
             switch (mediaType)
@@ -670,6 +671,65 @@ namespace MPF.Core
             return true;
         }
 
-#endregion
+        #endregion
+
+        #region Helper Functions
+
+        /// <summary>
+        /// Formats a list of volume labels and their corresponding filesystems
+        /// </summary>
+        /// <param name="labels">Dictionary of volume labels and their filesystems</param>
+        /// <returns>Formatted string of volume labels and their filesystems</returns>
+        private static string? FormatVolumeLabels(string? driveLabel, Dictionary<string, List<string>>? labels)
+        {
+
+            // Must have at least one label to format
+            if (driveLabel == null && (labels == null || labels.Count <= 0))
+                return null;
+
+            // If no labels given, use drive label
+            if (labels == null || labels.Count <= 0)
+            {
+                // Ignore common volume labels
+                if (Drive.GetRedumpSystemFromVolumeLabel(driveLabel) != null)
+                    return null;
+
+                return driveLabel;
+            }
+
+            // If only one label, don't mention fs
+            string firstLabel = labels.FirstOrDefault().Key;
+            if (labels.Count == 1 && (firstLabel == driveLabel || driveLabel == null))
+            {
+                // Ignore common volume labels
+                if (Drive.GetRedumpSystemFromVolumeLabel(firstLabel) != null)
+                    return null;
+
+                return firstLabel;
+            }
+
+            // Otherwise, state filesystem for each label
+            List<string> volLabels = [];
+            
+            // Begin formatted output with the label from Windows, if it is unique and not a common volume label
+            if (driveLabel != null && !labels.TryGetValue(driveLabel, out List<string>? value) && Drive.GetRedumpSystemFromVolumeLabel(driveLabel) != null)
+                volLabels.Add(driveLabel);
+
+            // Add remaining labels with their corresponding filesystems
+            foreach (KeyValuePair<string, List<string>> label in labels)
+            {
+                // Ignore common volume labels
+                if (Drive.GetRedumpSystemFromVolumeLabel(label.Key) == null)
+                    volLabels.Add($"{label.Key} ({string.Join(", ", [.. label.Value])})");
+            }
+
+            // Print each label separated by a comma and a space
+            if (volLabels == null)
+                return null;
+
+            return string.Join(", ", [.. volLabels]);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
- Parses ISO label from Redumper logs
- Parses ISO/Joliet/UDF label from DIC logs
- Adds formatted list of labels from logs to [T:VOL] tag, on top of whatever Windows sees
- Adds a `Dictionary<string, List<string>>? VolumeLabels` field to BaseParameters
- Makes `Drive.GetRedumpSystemFromVolumeLabel` a static method 

Attempts to fix #579 

Perhaps needs more testing, and figuring out where in Aaru logs the volume label is.
Note: With this change, Aaru still outputs "[T:VOL] %label%" exactly as prior functionality.