### PR TITLE
Correct missing space in PVD

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -13,6 +13,7 @@
 - Allow variables in output path (Deterous)
 - Check for presence of complete dump from other programs (Deterous)
 - Retrieve volume label from logs (Deterous)
+- Correct missing space in PVD (fuzz6001)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -2031,11 +2031,11 @@ namespace MPF.Core.Modules.Redumper
                     return null;
 
                 // Now that we're at the relevant entries, read each line in and concatenate
-                string? pvdString = "", line = sr.ReadLine()?.Trim();
+                string? pvdString = "", line = sr.ReadLine();
                 while (line?.StartsWith("03") == true)
                 {
                     pvdString += line + "\n";
-                    line = sr.ReadLine()?.Trim();
+                    line = sr.ReadLine();
                 }
 
                 return pvdString.TrimEnd('\n');


### PR DESCRIPTION
In rare cases, if there is a space at the end of each line in the PVD output, it will be missing.
![screenshot 1705405198](https://github.com/SabreTools/MPF/assets/2080945/a442eee5-d09f-47d2-af0f-d49655430ef6)

Therefore, remove Trim.
![screenshot 1705405411](https://github.com/SabreTools/MPF/assets/2080945/4dc87f8e-2786-4b2d-a7c1-65d7b7df3b0b)
