### PR TITLE
Prevent crashing on invalid parameters

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -14,6 +14,7 @@
 - Check for presence of complete dump from other programs (Deterous)
 - Retrieve volume label from logs (Deterous)
 - Correct missing space in PVD (fuzz6001)
+- Prevent crashing on invalid parameters (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/Modules/BaseParameters.cs
+++ b/MPF.Core/Modules/BaseParameters.cs
@@ -642,7 +642,8 @@ namespace MPF.Core.Modules
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
                 if (sbyte.TryParse(value, out sbyte sByteValue))
                     return (sbyte)(sByteValue * factor);
-                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && sbyte.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out sbyte sByteHexValue))
+                string hexValue = RemoveHexIdentifier(value);
+                if (sbyte.TryParse(hexValue, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out sbyte sByteHexValue))
                     return (sbyte)(sByteHexValue * factor);
                 return null;
             }
@@ -661,7 +662,8 @@ namespace MPF.Core.Modules
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
                 if (sbyte.TryParse(value, out sbyte sByteValue))
                     return (sbyte)(sByteValue * factor);
-                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && sbyte.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out sbyte sByteHexValue))
+                string hexValue = RemoveHexIdentifier(value);
+                if (sbyte.TryParse(hexValue, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out sbyte sByteHexValue))
                     return (sbyte)(sByteHexValue * factor);
                 return null;
             }
@@ -727,7 +729,8 @@ namespace MPF.Core.Modules
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
                 if (short.TryParse(value, out short shortValue))
                     return (short)(shortValue * factor);
-                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && short.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out short shortHexValue))
+                string hexValue = RemoveHexIdentifier(value);
+                if (short.TryParse(hexValue, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out short shortHexValue))
                     return (short)(shortHexValue * factor);
                 return null;
             }
@@ -746,7 +749,8 @@ namespace MPF.Core.Modules
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
                 if (short.TryParse(value, out short shortValue))
                     return (short)(shortValue * factor);
-                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && short.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out short shortHexValue))
+                string hexValue = RemoveHexIdentifier(value);
+                if (short.TryParse(hexValue, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out short shortHexValue))
                     return (short)(shortHexValue * factor);
                 return null;
             }
@@ -812,7 +816,8 @@ namespace MPF.Core.Modules
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
                 if (int.TryParse(value, out int intValue))
                     return (int)(intValue * factor);
-                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && int.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out int intHexValue))
+                string hexValue = RemoveHexIdentifier(value);
+                if (int.TryParse(hexValue, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out int intHexValue))
                     return (int)(intHexValue * factor);
                 return null;
             }
@@ -831,7 +836,8 @@ namespace MPF.Core.Modules
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
                 if (int.TryParse(value, out int intValue))
                     return (int)(intValue * factor);
-                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && int.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out int intHexValue))
+                string hexValue = RemoveHexIdentifier(value);
+                if (int.TryParse(hexValue, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out int intHexValue))
                     return (int)(intHexValue * factor);
                 return null;
             }
@@ -897,7 +903,8 @@ namespace MPF.Core.Modules
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
                 if (long.TryParse(value, out long longValue))
                     return (long)(longValue * factor);
-                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && long.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out long longHexValue))
+                string hexValue = RemoveHexIdentifier(value);
+                if (long.TryParse(hexValue, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out long longHexValue))
                     return (long)(longHexValue * factor);
                 return null;
             }
@@ -916,7 +923,8 @@ namespace MPF.Core.Modules
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
                 if (long.TryParse(value, out long longValue))
                     return (long)(longValue * factor);
-                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && long.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out long longHexValue))
+                string hexValue = RemoveHexIdentifier(value);
+                if (long.TryParse(hexValue, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out long longHexValue))
                     return (long)(longHexValue * factor);
                 return null;
             }
@@ -1058,7 +1066,8 @@ namespace MPF.Core.Modules
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
                 if (byte.TryParse(value, out byte byteValue))
                     return (byte)(byteValue * factor);
-                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && byte.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out byte byteHexValue))
+                string hexValue = RemoveHexIdentifier(value);
+                if (byte.TryParse(hexValue, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out byte byteHexValue))
                     return (byte)(byteHexValue * factor);
                 return null;
             }
@@ -1077,7 +1086,8 @@ namespace MPF.Core.Modules
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
                 if (byte.TryParse(value, out byte byteValue))
                     return (byte)(byteValue * factor);
-                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && byte.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out byte byteHexValue))
+                string hexValue = RemoveHexIdentifier(value);
+                if (byte.TryParse(hexValue, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out byte byteHexValue))
                     return (byte)(byteHexValue * factor);
                 return null;
             }
@@ -1145,6 +1155,27 @@ namespace MPF.Core.Modules
             }
 
             return (value, factor);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Removes a leading 0x if it exists, case insensitive
+        /// </summary>
+        /// <param name="value">String with removed leading 0x</param>
+        /// <returns></returns>
+        private static string RemoveHexIdentifier(string value)
+        {
+            if (value.Length <= 2)
+                return value;
+            if (value[0] != '0')
+                return value;
+            if (value[1] != 'x' && value[1] != 'X')
+                return value;
+
+            return value.Substring(2);
         }
 
         #endregion

--- a/MPF.Core/Modules/BaseParameters.cs
+++ b/MPF.Core/Modules/BaseParameters.cs
@@ -1157,10 +1157,6 @@ namespace MPF.Core.Modules
             return (value, factor);
         }
 
-        #endregion
-
-        #region Helpers
-
         /// <summary>
         /// Removes a leading 0x if it exists, case insensitive
         /// </summary>

--- a/MPF.Core/Modules/BaseParameters.cs
+++ b/MPF.Core/Modules/BaseParameters.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -639,10 +640,11 @@ namespace MPF.Core.Modules
                 i++;
 
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
-                bool isSByte = sbyte.TryParse(value, out sbyte sByteValue);
-                if (!isSByte)
-                    return null;
-                return (sbyte)(sByteValue * factor);
+                if (sbyte.TryParse(value, out sbyte sByteValue))
+                    return (sbyte)(sByteValue * factor);
+                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && sbyte.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out sbyte sByteHexValue))
+                    return (sbyte)(sByteHexValue * factor);
+                return null;
             }
             else if (parts[i].StartsWith(shortFlagString + "=") || parts[i].StartsWith(longFlagString + "="))
             {
@@ -657,10 +659,11 @@ namespace MPF.Core.Modules
 
                 this[longFlagString] = true;
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
-                bool isSByte = sbyte.TryParse(value, out sbyte sByteValue);
-                if (!isSByte)
-                    return null;
-                return (sbyte)(sByteValue * factor);
+                if (sbyte.TryParse(value, out sbyte sByteValue))
+                    return (sbyte)(sByteValue * factor);
+                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && sbyte.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out sbyte sByteHexValue))
+                    return (sbyte)(sByteHexValue * factor);
+                return null;
             }
 
             return SByte.MinValue;
@@ -722,10 +725,11 @@ namespace MPF.Core.Modules
                 this[longFlagString] = true;
                 i++;
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
-                bool isShort = short.TryParse(value, out short shortValue);
-                if (!isShort)
-                    return null;
-                return (byte)(shortValue * factor);
+                if (short.TryParse(value, out short shortValue))
+                    return (short)(shortValue * factor);
+                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && short.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out short shortHexValue))
+                    return (short)(shortHexValue * factor);
+                return null;
             }
             else if (parts[i].StartsWith(shortFlagString + "=") || parts[i].StartsWith(longFlagString + "="))
             {
@@ -740,10 +744,11 @@ namespace MPF.Core.Modules
 
                 this[longFlagString] = true;
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
-                bool isShort = short.TryParse(value, out short shortValue);
-                if (!isShort)
-                    return null;
-                return (byte)(shortValue * factor);
+                if (short.TryParse(value, out short shortValue))
+                    return (short)(shortValue * factor);
+                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && short.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out short shortHexValue))
+                    return (short)(shortHexValue * factor);
+                return null;
             }
 
             return Int16.MinValue;
@@ -805,10 +810,11 @@ namespace MPF.Core.Modules
                 this[longFlagString] = true;
                 i++;
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
-                bool isInt = int.TryParse(value, out int intValue);
-                if (!isInt)
-                    return null;
-                return (int)(intValue * factor);
+                if (int.TryParse(value, out int intValue))
+                    return (int)(intValue * factor);
+                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && int.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out int intHexValue))
+                    return (int)(intHexValue * factor);
+                return null;
             }
             else if (parts[i].StartsWith(shortFlagString + "=") || parts[i].StartsWith(longFlagString + "="))
             {
@@ -823,10 +829,11 @@ namespace MPF.Core.Modules
 
                 this[longFlagString] = true;
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
-                bool isInt = int.TryParse(value, out int intValue);
-                if (!isInt)
-                    return null;
-                return (int)(intValue * factor);
+                if (int.TryParse(value, out int intValue))
+                    return (int)(intValue * factor);
+                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && int.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out int intHexValue))
+                    return (int)(intHexValue * factor);
+                return null;
             }
 
             return Int32.MinValue;
@@ -888,10 +895,11 @@ namespace MPF.Core.Modules
                 this[longFlagString] = true;
                 i++;
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
-                bool isLong = long.TryParse(value, out long longValue);
-                if (!isLong)
-                    return null;
-                return (int)(longValue * factor);
+                if (long.TryParse(value, out long longValue))
+                    return (long)(longValue * factor);
+                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && long.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out long longHexValue))
+                    return (long)(longHexValue * factor);
+                return null;
             }
             else if (parts[i].StartsWith(shortFlagString + "=") || parts[i].StartsWith(longFlagString + "="))
             {
@@ -906,10 +914,11 @@ namespace MPF.Core.Modules
 
                 this[longFlagString] = true;
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
-                bool isLong = long.TryParse(value, out long longValue);
-                if (!isLong)
-                    return null;
-                return (int)(longValue * factor);
+                if (long.TryParse(value, out long longValue))
+                    return (long)(longValue * factor);
+                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && long.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out long longHexValue))
+                    return (long)(longHexValue * factor);
+                return null;
             }
 
             return Int64.MinValue;
@@ -1047,10 +1056,11 @@ namespace MPF.Core.Modules
                 i++;
 
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
-                bool isByte = byte.TryParse(value, out byte byteValue);
-                if (!isByte)
-                    return null;
-                return (byte)(byteValue * factor);
+                if (byte.TryParse(value, out byte byteValue))
+                    return (byte)(byteValue * factor);
+                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && byte.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out byte byteHexValue))
+                    return (byte)(byteHexValue * factor);
+                return null;
             }
             else if (parts[i].StartsWith(shortFlagString + "=") || parts[i].StartsWith(longFlagString + "="))
             {
@@ -1065,10 +1075,11 @@ namespace MPF.Core.Modules
 
                 this[longFlagString] = true;
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
-                bool isByte = byte.TryParse(value, out byte byteValue);
-                if (!isByte)
-                    return null;
-                return (byte)(byteValue * factor);
+                if (byte.TryParse(value, out byte byteValue))
+                    return (byte)(byteValue * factor);
+                if (value.Length > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X') && byte.TryParse(value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out byte byteHexValue))
+                    return (byte)(byteHexValue * factor);
+                return null;
             }
 
             return Byte.MinValue;

--- a/MPF.Core/Modules/BaseParameters.cs
+++ b/MPF.Core/Modules/BaseParameters.cs
@@ -639,7 +639,10 @@ namespace MPF.Core.Modules
                 i++;
 
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
-                return (sbyte)(sbyte.Parse(value) * factor);
+                bool isSByte = sbyte.TryParse(value, out sbyte sByteValue);
+                if (!isSByte)
+                    return null;
+                return (sbyte)(sByteValue * factor);
             }
             else if (parts[i].StartsWith(shortFlagString + "=") || parts[i].StartsWith(longFlagString + "="))
             {
@@ -654,7 +657,10 @@ namespace MPF.Core.Modules
 
                 this[longFlagString] = true;
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
-                return (sbyte)(sbyte.Parse(value) * factor);
+                bool isSByte = sbyte.TryParse(value, out sbyte sByteValue);
+                if (!isSByte)
+                    return null;
+                return (sbyte)(sByteValue * factor);
             }
 
             return SByte.MinValue;
@@ -716,7 +722,10 @@ namespace MPF.Core.Modules
                 this[longFlagString] = true;
                 i++;
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
-                return (short)(short.Parse(value) * factor);
+                bool isShort = short.TryParse(value, out short shortValue);
+                if (!isShort)
+                    return null;
+                return (byte)(shortValue * factor);
             }
             else if (parts[i].StartsWith(shortFlagString + "=") || parts[i].StartsWith(longFlagString + "="))
             {
@@ -731,7 +740,10 @@ namespace MPF.Core.Modules
 
                 this[longFlagString] = true;
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
-                return (short)(short.Parse(value) * factor);
+                bool isShort = short.TryParse(value, out short shortValue);
+                if (!isShort)
+                    return null;
+                return (byte)(shortValue * factor);
             }
 
             return Int16.MinValue;
@@ -793,7 +805,10 @@ namespace MPF.Core.Modules
                 this[longFlagString] = true;
                 i++;
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
-                return (int)(int.Parse(value) * factor);
+                bool isInt = int.TryParse(value, out int intValue);
+                if (!isInt)
+                    return null;
+                return (int)(intValue * factor);
             }
             else if (parts[i].StartsWith(shortFlagString + "=") || parts[i].StartsWith(longFlagString + "="))
             {
@@ -808,7 +823,10 @@ namespace MPF.Core.Modules
 
                 this[longFlagString] = true;
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
-                return (int)(int.Parse(value) * factor);
+                bool isInt = int.TryParse(value, out int intValue);
+                if (!isInt)
+                    return null;
+                return (int)(intValue * factor);
             }
 
             return Int32.MinValue;
@@ -870,7 +888,10 @@ namespace MPF.Core.Modules
                 this[longFlagString] = true;
                 i++;
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
-                return long.Parse(value) * factor;
+                bool isLong = long.TryParse(value, out long longValue);
+                if (!isLong)
+                    return null;
+                return (int)(longValue * factor);
             }
             else if (parts[i].StartsWith(shortFlagString + "=") || parts[i].StartsWith(longFlagString + "="))
             {
@@ -885,7 +906,10 @@ namespace MPF.Core.Modules
 
                 this[longFlagString] = true;
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
-                return long.Parse(value) * factor;
+                bool isLong = long.TryParse(value, out long longValue);
+                if (!isLong)
+                    return null;
+                return (int)(longValue * factor);
             }
 
             return Int64.MinValue;
@@ -1023,7 +1047,10 @@ namespace MPF.Core.Modules
                 i++;
 
                 (string value, long factor) = ExtractFactorFromValue(parts[i]);
-                return (byte)(byte.Parse(value) * factor);
+                bool isByte = byte.TryParse(value, out byte byteValue);
+                if (!isByte)
+                    return null;
+                return (byte)(byteValue * factor);
             }
             else if (parts[i].StartsWith(shortFlagString + "=") || parts[i].StartsWith(longFlagString + "="))
             {
@@ -1038,14 +1065,17 @@ namespace MPF.Core.Modules
 
                 this[longFlagString] = true;
                 (string value, long factor) = ExtractFactorFromValue(valuePart);
-                return (byte)(byte.Parse(value) * factor);
+                bool isByte = byte.TryParse(value, out byte byteValue);
+                if (!isByte)
+                    return null;
+                return (byte)(byteValue * factor);
             }
 
             return Byte.MinValue;
         }
 
         /// <summary>
-        /// Get yhe trimmed value and multiplication factor from a value
+        /// Get the trimmed value and multiplication factor from a value
         /// </summary>
         /// <param name="value">String value to treat as suffixed number</param>
         /// <returns>Trimmed value and multiplication factor</returns>


### PR DESCRIPTION
Replaces a bunch of .Parse() with .TryParse() 

Also probably fixes #630 