### PR TITLE
Differentiate CD32 from CDTV

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -16,6 +16,7 @@
 - Correct missing space in PVD (fuzz6001)
 - Prevent crashing on invalid parameters (Deterous)
 - Detect CDTV discs (Deterous)
+- Differentiate CD32 from CDTV (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/Data/Drive.cs
+++ b/MPF.Core/Data/Drive.cs
@@ -307,16 +307,17 @@ namespace MPF.Core.Data
                 return RedumpSystem.BandaiPippin;
             }
 
-            // Commodore CDTV (currently also detects CD32 as CDTV)
+            // Commodore CDTV/CD32
 #if NET20 || NET35
-            if (File.Exists(Path.Combine(Path.Combine(this.Name, "S"), "STARTUP-SEQUENCE"))
-                || File.Exists(Path.Combine(this.Name, "CDTV.TM")))
+            if (File.Exists(Path.Combine(Path.Combine(this.Name, "S"), "STARTUP-SEQUENCE")))
 #else
-            if (File.Exists(Path.Combine(this.Name, "S", "STARTUP-SEQUENCE"))
-                || File.Exists(Path.Combine(this.Name, "CDTV.TM")))
+            if (File.Exists(Path.Combine(this.Name, "S", "STARTUP-SEQUENCE")))
 #endif
             {
-                return RedumpSystem.CommodoreAmigaCDTV;
+                if (File.Exists(Path.Combine(this.Name, "CDTV.TM")))
+                    return RedumpSystem.CommodoreAmigaCDTV;
+                else
+                    return RedumpSystem.CommodoreAmigaCD32;
             }
 
             // Mattel Fisher-Price iXL


### PR DESCRIPTION
If `S/STARTUP-SEQUENCE` is found, it's either CDTV or CD32
If `CDTV.TM` is found, it *must* be CDTV, but I'm told there exists CDTV discs without that file
This commit defaults to CD32 if it doesn't contain `CDTV.TM`