### PR TITLE
Add a GUI for MPF.Check

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -18,6 +18,7 @@
 - Detect CDTV discs (Deterous)
 - Differentiate CD32 from CDTV (Deterous)
 - Normalise Disc Titles in Submission Info (Deterous)
+- Add a GUI for MPF.Check (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/UI/ViewModels/CheckDumpViewModel.cs
+++ b/MPF.Core/UI/ViewModels/CheckDumpViewModel.cs
@@ -400,7 +400,6 @@ namespace MPF.Core.UI.ViewModels
         /// <returns>An error message if failed, otherwise string.Empty/null</returns>
         public string? CheckDump(Func<SubmissionInfo?, (bool?, SubmissionInfo?)> processUserInfo)
         {
-
             if (string.IsNullOrEmpty(InputPath))
                 return "Invalid Input path";
 

--- a/MPF.Core/UI/ViewModels/CheckDumpViewModel.cs
+++ b/MPF.Core/UI/ViewModels/CheckDumpViewModel.cs
@@ -397,7 +397,7 @@ namespace MPF.Core.UI.ViewModels
         /// <summary>
         /// Performs MPF.Check functionality
         /// </summary>
-        /// <returns>An error message if failed, otherwise null</returns>
+        /// <returns>An error message if failed, otherwise string.Empty/null</returns>
         public string? CheckDump()
         {
 
@@ -408,10 +408,7 @@ namespace MPF.Core.UI.ViewModels
                 return "Input Path is not a valid file";
 
             // Populate an environment
-            //string driveLetter;
-            //Drive? drive = Drive.Create(null, driveLetter);
-            Drive? drive = null;
-            var env = new DumpEnvironment(Options, Path.GetFullPath(this.InputPath.Trim('"')), drive, this.CurrentSystem, this.CurrentMediaType, this.CurrentProgram, parameters: null);
+            var env = new DumpEnvironment(Options, Path.GetFullPath(this.InputPath.Trim('"')), null, this.CurrentSystem, this.CurrentMediaType, this.CurrentProgram, parameters: null);
 
             // Make new Progress objects
             var resultProgress = new Progress<Result>();

--- a/MPF.Core/UI/ViewModels/CheckDumpViewModel.cs
+++ b/MPF.Core/UI/ViewModels/CheckDumpViewModel.cs
@@ -1,0 +1,398 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using MPF.Core.Data;
+using MPF.Core.UI.ComboBoxItems;
+using MPF.Core.Utilities;
+using SabreTools.RedumpLib.Data;
+
+namespace MPF.Core.UI.ViewModels
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public class CheckDumpViewModel : INotifyPropertyChanged
+    {
+        #region Fields
+
+        /// <summary>
+        /// Access to the current options
+        /// </summary>
+        public Data.Options Options
+        {
+            get => _options;
+            set
+            {
+                _options = value;
+                OptionsLoader.SaveToConfig(_options);
+            }
+        }
+        private Data.Options _options;
+
+        /// <summary>
+        /// Indicates if SelectionChanged events can be executed
+        /// </summary>
+        public bool CanExecuteSelectionChanged { get; private set; } = false;
+
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Currently selected system value
+        /// </summary>
+        public RedumpSystem? CurrentSystem
+        {
+            get => _currentSystem;
+            set
+            {
+                _currentSystem = value;
+                TriggerPropertyChanged(nameof(CurrentSystem));
+            }
+        }
+        private RedumpSystem? _currentSystem;
+
+        /// <summary>
+        /// Indicates the status of the system type combo box
+        /// </summary>
+        public bool SystemTypeComboBoxEnabled
+        {
+            get => _systemTypeComboBoxEnabled;
+            set
+            {
+                _systemTypeComboBoxEnabled = value;
+                TriggerPropertyChanged(nameof(SystemTypeComboBoxEnabled));
+            }
+        }
+        private bool _systemTypeComboBoxEnabled;
+
+        /// <summary>
+        /// Currently selected media type value
+        /// </summary>
+        public MediaType? CurrentMediaType
+        {
+            get => _currentMediaType;
+            set
+            {
+                _currentMediaType = value;
+                TriggerPropertyChanged(nameof(CurrentMediaType));
+            }
+        }
+        private MediaType? _currentMediaType;
+
+        /// <summary>
+        /// Indicates the status of the media type combo box
+        /// </summary>
+        public bool MediaTypeComboBoxEnabled
+        {
+            get => _mediaTypeComboBoxEnabled;
+            set
+            {
+                _mediaTypeComboBoxEnabled = value;
+                TriggerPropertyChanged(nameof(MediaTypeComboBoxEnabled));
+            }
+        }
+        private bool _mediaTypeComboBoxEnabled;
+
+        /// <summary>
+        /// Currently provided input path
+        /// </summary>
+        public string InputPath
+        {
+            get => _inputPath;
+            set
+            {
+                _inputPath = value;
+                TriggerPropertyChanged(nameof(InputPath));
+            }
+        }
+        private string _inputPath;
+
+        /// <summary>
+        /// Indicates the status of the input path text box
+        /// </summary>
+        public bool InputPathTextBoxEnabled
+        {
+            get => _inputPathTextBoxEnabled;
+            set
+            {
+                _inputPathTextBoxEnabled = value;
+                TriggerPropertyChanged(nameof(InputPathTextBoxEnabled));
+            }
+        }
+        private bool _inputPathTextBoxEnabled;
+
+        /// <summary>
+        /// Indicates the status of the input path browse button
+        /// </summary>
+        public bool InputPathBrowseButtonEnabled
+        {
+            get => _inputPathBrowseButtonEnabled;
+            set
+            {
+                _inputPathBrowseButtonEnabled = value;
+                TriggerPropertyChanged(nameof(InputPathBrowseButtonEnabled));
+            }
+        }
+        private bool _inputPathBrowseButtonEnabled;
+
+        /// <summary>
+        /// Currently selected dumping program
+        /// </summary>
+        public InternalProgram CurrentProgram
+        {
+            get => _currentProgram;
+            set
+            {
+                _currentProgram = value;
+                TriggerPropertyChanged(nameof(CurrentProgram));
+            }
+        }
+        private InternalProgram _currentProgram;
+
+        /// <summary>
+        /// Indicates the status of the dumping program combo box
+        /// </summary>
+        public bool DumpingProgramComboBoxEnabled
+        {
+            get => _dumpingProgramComboBoxEnabled;
+            set
+            {
+                _dumpingProgramComboBoxEnabled = value;
+                TriggerPropertyChanged(nameof(DumpingProgramComboBoxEnabled));
+            }
+        }
+        private bool _dumpingProgramComboBoxEnabled;
+
+        /// <summary>
+        /// Indicates the status of the check dump button
+        /// </summary>
+        public bool CheckDumpButtonEnabled
+        {
+            get => _checkDumpButtonEnabled;
+            set
+            {
+                _checkDumpButtonEnabled = value;
+                TriggerPropertyChanged(nameof(CheckDumpButtonEnabled));
+            }
+        }
+        private bool _checkDumpButtonEnabled;
+
+        #endregion
+
+        #region List Properties
+
+        /// <summary>
+        /// Current list of supported media types
+        /// </summary>
+        public List<Element<MediaType>>? MediaTypes
+        {
+            get => _mediaTypes;
+            set
+            {
+                _mediaTypes = value;
+                TriggerPropertyChanged(nameof(MediaTypes));
+            }
+        }
+        private List<Element<MediaType>>? _mediaTypes;
+
+        /// <summary>
+        /// Current list of supported system profiles
+        /// </summary>
+        public List<RedumpSystemComboBoxItem> Systems
+        {
+            get => _systems;
+            set
+            {
+                _systems = value;
+                TriggerPropertyChanged(nameof(Systems));
+            }
+        }
+        private List<RedumpSystemComboBoxItem> _systems;
+
+        /// <summary>
+        /// List of available internal programs
+        /// </summary>
+        public List<Element<InternalProgram>> InternalPrograms
+        {
+            get => _internalPrograms;
+            set
+            {
+                _internalPrograms = value;
+                TriggerPropertyChanged(nameof(InternalPrograms));
+            }
+        }
+        private List<Element<InternalProgram>> _internalPrograms;
+
+        #endregion
+
+        /// <summary>
+        /// Constructor for pure view model
+        /// </summary>
+        public CheckDumpViewModel()
+        {
+            _options = OptionsLoader.LoadFromConfig();
+            _internalPrograms = [];
+            _inputPath = string.Empty;
+            _systems = [];
+
+            SystemTypeComboBoxEnabled = true;
+            InputPathTextBoxEnabled = true;
+            InputPathBrowseButtonEnabled = true;
+            MediaTypeComboBoxEnabled = true;
+            DumpingProgramComboBoxEnabled = true;
+            CheckDumpButtonEnabled = false;
+
+            MediaTypes = [];
+            Systems = RedumpSystemComboBoxItem.GenerateElements().ToList();
+            InternalPrograms = [];
+
+            PopulateMediaType();
+            PopulateInternalPrograms();
+            EnableEventHandlers();
+        }
+
+        #region Property Updates
+
+        /// <summary>
+        /// Trigger a property changed event
+        /// </summary>
+        private void TriggerPropertyChanged(string propertyName)
+        {
+            // Disable event handlers temporarily
+            bool cachedCanExecuteSelectionChanged = CanExecuteSelectionChanged;
+            DisableEventHandlers();
+
+            // If the property change event is initialized
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+            // Reenable event handlers, if necessary
+            if (cachedCanExecuteSelectionChanged) EnableEventHandlers();
+        }
+
+        #endregion
+
+        #region UI Commands
+
+        /// <summary>
+        /// Change the currently selected system
+        /// </summary>
+        public void ChangeSystem()
+        {
+            PopulateMediaType();
+            this.CheckDumpButtonEnabled = ShouldEnableCheckDumpButton();
+        }
+
+        /// <summary>
+        /// Change the currently selected media type
+        /// </summary>
+        public void ChangeMediaType()
+        {
+            this.CheckDumpButtonEnabled = ShouldEnableCheckDumpButton();
+        }
+
+        /// <summary>
+        /// Change the currently selected dumping program
+        /// </summary>
+        public void ChangeDumpingProgram()
+        {
+            this.CheckDumpButtonEnabled = ShouldEnableCheckDumpButton();
+        }
+
+        /// <summary>
+        /// Change the currently selected input path
+        /// </summary>
+        public void ChangeInputPath()
+        {
+            this.CheckDumpButtonEnabled = ShouldEnableCheckDumpButton();
+        }
+
+        #endregion
+
+        #region Population
+
+        /// <summary>
+        /// Populate media type according to system type
+        /// </summary>
+        private void PopulateMediaType()
+        {
+            // Disable other UI updates
+            bool cachedCanExecuteSelectionChanged = CanExecuteSelectionChanged;
+            DisableEventHandlers();
+
+            if (this.CurrentSystem != null)
+            {
+                var mediaTypeValues = this.CurrentSystem.MediaTypes();
+                int index = mediaTypeValues.FindIndex(m => m == this.CurrentMediaType);
+
+                MediaTypes = mediaTypeValues.Select(m => new Element<MediaType>(m ?? MediaType.NONE)).ToList();
+                this.MediaTypeComboBoxEnabled = MediaTypes.Count > 1;
+                this.CurrentMediaType = (index > -1 ? MediaTypes[index] : MediaTypes[0]);
+            }
+            else
+            {
+                this.MediaTypeComboBoxEnabled = false;
+                this.MediaTypes = null;
+                this.CurrentMediaType = null;
+            }
+
+            // Reenable event handlers, if necessary
+            if (cachedCanExecuteSelectionChanged) EnableEventHandlers();
+        }
+
+        /// <summary>
+        /// Populate media type according to system type
+        /// </summary>
+        private void PopulateInternalPrograms()
+        {
+            // Disable other UI updates
+            bool cachedCanExecuteSelectionChanged = CanExecuteSelectionChanged;
+            DisableEventHandlers();
+
+            // Get the current internal program
+            InternalProgram internalProgram = this.Options.InternalProgram;
+
+            // Create a static list of supported Check programs, not everything
+            var internalPrograms = new List<InternalProgram> { InternalProgram.DiscImageCreator, InternalProgram.Aaru, InternalProgram.CleanRip, InternalProgram.Redumper, InternalProgram.UmdImageCreator };
+            InternalPrograms = internalPrograms.Select(ip => new Element<InternalProgram>(ip)).ToList();
+
+            // Select the current default dumping program
+            int currentIndex = InternalPrograms.FindIndex(m => m == internalProgram);
+            this.CurrentProgram = (currentIndex > -1 ? InternalPrograms[currentIndex].Value : InternalPrograms[0].Value);
+
+            // Reenable event handlers, if necessary
+            if (cachedCanExecuteSelectionChanged) EnableEventHandlers();
+        }
+
+        #endregion
+
+        #region UI Functionality
+
+        private bool ShouldEnableCheckDumpButton()
+        {
+            return this.CurrentSystem != null && this.CurrentMediaType != null && this.InputPath != string.Empty;
+        }
+
+        /// <summary>
+        /// Enable all textbox and combobox event handlers
+        /// </summary>
+        private void EnableEventHandlers()
+        {
+            CanExecuteSelectionChanged = true;
+        }
+
+        /// <summary>
+        /// Disable all textbox and combobox event handlers
+        /// </summary>
+        private void DisableEventHandlers()
+        {
+            CanExecuteSelectionChanged = false;
+        }
+
+        #endregion
+    }
+}

--- a/MPF.Core/UI/ViewModels/CheckDumpViewModel.cs
+++ b/MPF.Core/UI/ViewModels/CheckDumpViewModel.cs
@@ -398,7 +398,7 @@ namespace MPF.Core.UI.ViewModels
         /// Performs MPF.Check functionality
         /// </summary>
         /// <returns>An error message if failed, otherwise string.Empty/null</returns>
-        public string? CheckDump()
+        public string? CheckDump(Func<SubmissionInfo?, (bool?, SubmissionInfo?)> processUserInfo)
         {
 
             if (string.IsNullOrEmpty(InputPath))
@@ -422,7 +422,7 @@ namespace MPF.Core.UI.ViewModels
                 resultTask.Wait();
                 var result = resultTask.Result;
 #else
-            var result = env.VerifyAndSaveDumpOutput(resultProgress, protectionProgress).ConfigureAwait(false).GetAwaiter().GetResult();
+            var result = env.VerifyAndSaveDumpOutput(resultProgress, protectionProgress, processUserInfo).ConfigureAwait(false).GetAwaiter().GetResult();
 #endif
 
             return result.Message;

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -77,6 +77,20 @@ namespace MPF.Core.UI.ViewModels
         #region Properties
 
         /// <summary>
+        /// Indicates the status of the check dump menu item
+        /// </summary>
+        public bool CheckDumpMenuItemEnabled
+        {
+            get => _checkDumpMenuItemEnabled;
+            set
+            {
+                _checkDumpMenuItemEnabled = value;
+                TriggerPropertyChanged(nameof(CheckDumpMenuItemEnabled));
+            }
+        }
+        private bool _checkDumpMenuItemEnabled;
+
+        /// <summary>
         /// Indicates the status of the options menu item
         /// </summary>
         public bool OptionsMenuItemEnabled
@@ -507,6 +521,7 @@ namespace MPF.Core.UI.ViewModels
             _systems = [];
 
             OptionsMenuItemEnabled = true;
+            CheckDumpMenuItemEnabled = true;
             SystemTypeComboBoxEnabled = true;
             MediaTypeComboBoxEnabled = true;
             OutputPathTextBoxEnabled = true;

--- a/MPF.UI.Core/Windows/CheckDumpWindow.xaml
+++ b/MPF.UI.Core/Windows/CheckDumpWindow.xaml
@@ -1,0 +1,130 @@
+﻿<coreWindows:WindowBase x:Class="MPF.UI.Core.Windows.CheckDumpWindow"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:core="clr-namespace:MPF.UI.Core"
+                        xmlns:coreWindows="clr-namespace:MPF.UI.Core.Windows"
+                        xmlns:viewModels="clr-namespace:MPF.Core.UI.ViewModels;assembly=MPF.Core"
+                        mc:Ignorable="d"
+                        Title="Check Existing Dump" Width="600" WindowStyle="None"
+                        WindowStartupLocation="CenterOwner" ResizeMode="CanMinimize" SizeToContent="Height"
+                        BorderBrush="DarkGray" BorderThickness="2">
+
+    <Window.DataContext>
+        <viewModels:CheckDumpViewModel/>
+    </Window.DataContext>
+    <Window.Resources>
+        <core:ElementConverter x:Key="ElementConverter" />
+    </Window.Resources>
+
+    <Grid>
+        <StackPanel Orientation="Vertical">
+            <Grid Margin="0,2,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="25"/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition Width="50"/>
+                </Grid.ColumnDefinitions>
+
+                <Image Grid.Column="0" Source="/Images/Icon.ico" Height="20" Width="20" Margin="1" />
+                <Label Grid.Column="1" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" MouseDown="TitleMouseDown">
+                    <Label.Content>
+                        <Run FontWeight="Bold" Text="Check Existing Dump" />
+                    </Label.Content>
+                    <Label.ContextMenu>
+                        <ContextMenu Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
+                                     Foreground="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                     Style="{DynamicResource CustomContextMenuStyle}">
+                            <MenuItem Header="Minimize" Click="MinimizeButtonClick" Width="185"
+                                      Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
+                                      Foreground="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                      Template="{DynamicResource CustomMenuItemTemplate}"/>
+                            <MenuItem Header="Close" Click="CloseButtonClick" Width="185"
+                                      Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
+                                      Foreground="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                      Template="{DynamicResource CustomMenuItemTemplate}"/>
+                        </ContextMenu>
+                    </Label.ContextMenu>
+                </Label>
+                <Grid Grid.Column="5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+
+                    <Button x:Name="MinimizeButton" Grid.Column="0" BorderThickness="0" Background="Transparent" Style="{DynamicResource CustomButtonStyle}" Click="MinimizeButtonClick">
+                        <Path Data="M 0,0 L 10,0" Stroke="{Binding Path=Foreground,RelativeSource={RelativeSource AncestorType={x:Type Button}}}" StrokeThickness="1"/>
+                    </Button>
+                    <Button x:Name="CloseButton" Grid.Column="1" BorderThickness="0" Background="Transparent" Style="{DynamicResource CustomButtonStyle}" Click="CloseButtonClick">
+                        <Path Data="M 0,0 L 12,12 M 0,12 L 12,0" Stroke="{Binding Path=Foreground,RelativeSource={RelativeSource AncestorType={x:Type Button}}}" StrokeThickness="1"/>
+                    </Button>
+                </Grid>
+            </Grid>
+
+            <GroupBox Margin="5,5,5,5" HorizontalAlignment="Stretch" Header="Settings">
+                <Grid Margin="5,5,5,5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="2.5*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+
+                    <Label x:Name="SystemMediaTypeLabel" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Content="System/Media Type" />
+                    <ComboBox x:Name="SystemTypeComboBox" Grid.Row="0" Grid.Column="1" Height="22" Width="250" HorizontalAlignment="Left"
+                  ItemsSource="{Binding Systems}" SelectedItem="{Binding Path=CurrentSystem, Converter={StaticResource ElementConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                  IsEnabled="{Binding SystemTypeComboBoxEnabled}" Style="{DynamicResource CustomComboBoxStyle}">
+                        <ComboBox.ItemContainerStyle>
+                            <Style TargetType="{x:Type ComboBoxItem}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsHeader}" Value="True">
+                                        <Setter Property="IsEnabled" Value="False"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ComboBox.ItemContainerStyle>
+                    </ComboBox>
+                    <ComboBox x:Name="MediaTypeComboBox" Grid.Row="0" Grid.Column="1" Height="22" Width="140" HorizontalAlignment="Right"
+                  ItemsSource="{Binding MediaTypes}" SelectedItem="{Binding Path=CurrentMediaType, Converter={StaticResource ElementConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                  IsEnabled="{Binding MediaTypeComboBoxEnabled}" Style="{DynamicResource CustomComboBoxStyle}" />
+
+                    <Label x:Name="InputPathLabel" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Content="Input Path"/>
+                    <TextBox x:Name="InputPathTextBox" Grid.Row="1" Grid.Column="1" Height="22" Width="345" HorizontalAlignment="Left" VerticalContentAlignment="Center"
+                 Text="{Binding InputPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 IsEnabled="{Binding InputPathTextBoxEnabled}" />
+                    <Button x:Name="InputPathBrowseButton" Grid.Row="1" Grid.Column="1" Height="22" Width="50" HorizontalAlignment="Right" Content="Browse"
+                IsEnabled="{Binding InputPathBrowseButtonEnabled}" Style="{DynamicResource CustomButtonStyle}"/>
+
+                    <Label x:Name="DumpingProgramLabel" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Content="Dumping Program"/>
+                    <ComboBox x:Name="DumpingProgramComboBox" Grid.Row="4" Grid.Column="1" Height="22" Width="250" HorizontalAlignment="Left"
+                  ItemsSource="{Binding InternalPrograms}" SelectedItem="{Binding Path=CurrentProgram, Converter={StaticResource ElementConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                  IsEnabled="{Binding DumpingProgramComboBoxEnabled}" Style="{DynamicResource CustomComboBoxStyle}" />
+                </Grid>
+            </GroupBox>
+
+            <!-- Check Dump / Cancel -->
+            <GroupBox Margin="5,5,5,5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <UniformGrid Columns="4" Margin="5,5,5,5" Height="28">
+                    <Label/>
+                    <!-- Empty label for padding -->
+                    <Button Name="CheckDumpButton" Height="25" Width="80" IsDefault="True" Content="Check Dump"
+                            IsEnabled="{Binding CheckDumpButtonEnabled}" Style="{DynamicResource CustomButtonStyle}" />
+                    <Button Name="CancelButton" Height="25" Width="80" IsCancel="True" Content="Cancel"
+                            Style="{DynamicResource CustomButtonStyle}" />
+                    <Label/>
+                    <!-- Empty label for padding -->
+                </UniformGrid>
+            </GroupBox>
+        </StackPanel>
+    </Grid>
+</coreWindows:WindowBase>

--- a/MPF.UI.Core/Windows/CheckDumpWindow.xaml
+++ b/MPF.UI.Core/Windows/CheckDumpWindow.xaml
@@ -80,8 +80,15 @@
                         <RowDefinition/>
                     </Grid.RowDefinitions>
 
-                    <Label x:Name="SystemMediaTypeLabel" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Content="System/Media Type" />
-                    <ComboBox x:Name="SystemTypeComboBox" Grid.Row="0" Grid.Column="1" Height="22" Width="250" HorizontalAlignment="Left"
+                    <Label x:Name="InputPathLabel" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Content="Input Path"/>
+                    <TextBox x:Name="InputPathTextBox" Grid.Row="0" Grid.Column="1" Height="22" Width="345" HorizontalAlignment="Left" VerticalContentAlignment="Center"
+                 Text="{Binding InputPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 IsEnabled="{Binding InputPathTextBoxEnabled}" />
+                    <Button x:Name="InputPathBrowseButton" Grid.Row="0" Grid.Column="1" Height="22" Width="50" HorizontalAlignment="Right" Content="Browse"
+                IsEnabled="{Binding InputPathBrowseButtonEnabled}" Style="{DynamicResource CustomButtonStyle}"/>
+
+                    <Label x:Name="SystemMediaTypeLabel" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Content="System/Media Type" />
+                    <ComboBox x:Name="SystemTypeComboBox" Grid.Row="1" Grid.Column="1" Height="22" Width="250" HorizontalAlignment="Left"
                   ItemsSource="{Binding Systems}" SelectedItem="{Binding Path=CurrentSystem, Converter={StaticResource ElementConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                   IsEnabled="{Binding SystemTypeComboBoxEnabled}" Style="{DynamicResource CustomComboBoxStyle}">
                         <ComboBox.ItemContainerStyle>
@@ -94,19 +101,12 @@
                             </Style>
                         </ComboBox.ItemContainerStyle>
                     </ComboBox>
-                    <ComboBox x:Name="MediaTypeComboBox" Grid.Row="0" Grid.Column="1" Height="22" Width="140" HorizontalAlignment="Right"
+                    <ComboBox x:Name="MediaTypeComboBox" Grid.Row="1" Grid.Column="1" Height="22" Width="140" HorizontalAlignment="Right"
                   ItemsSource="{Binding MediaTypes}" SelectedItem="{Binding Path=CurrentMediaType, Converter={StaticResource ElementConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                   IsEnabled="{Binding MediaTypeComboBoxEnabled}" Style="{DynamicResource CustomComboBoxStyle}" />
 
-                    <Label x:Name="InputPathLabel" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Content="Input Path"/>
-                    <TextBox x:Name="InputPathTextBox" Grid.Row="1" Grid.Column="1" Height="22" Width="345" HorizontalAlignment="Left" VerticalContentAlignment="Center"
-                 Text="{Binding InputPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                 IsEnabled="{Binding InputPathTextBoxEnabled}" />
-                    <Button x:Name="InputPathBrowseButton" Grid.Row="1" Grid.Column="1" Height="22" Width="50" HorizontalAlignment="Right" Content="Browse"
-                IsEnabled="{Binding InputPathBrowseButtonEnabled}" Style="{DynamicResource CustomButtonStyle}"/>
-
-                    <Label x:Name="DumpingProgramLabel" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Content="Dumping Program"/>
-                    <ComboBox x:Name="DumpingProgramComboBox" Grid.Row="4" Grid.Column="1" Height="22" Width="250" HorizontalAlignment="Left"
+                    <Label x:Name="DumpingProgramLabel" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Content="Dumping Program"/>
+                    <ComboBox x:Name="DumpingProgramComboBox" Grid.Row="2" Grid.Column="1" Height="22" Width="250" HorizontalAlignment="Left"
                   ItemsSource="{Binding InternalPrograms}" SelectedItem="{Binding Path=CurrentProgram, Converter={StaticResource ElementConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                   IsEnabled="{Binding DumpingProgramComboBoxEnabled}" Style="{DynamicResource CustomComboBoxStyle}" />
                 </Grid>

--- a/MPF.UI.Core/Windows/CheckDumpWindow.xaml.cs
+++ b/MPF.UI.Core/Windows/CheckDumpWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using MPF.Core.UI.ViewModels;
+using SabreTools.RedumpLib.Data;
 using WPFCustomMessageBox;
 using WinForms = System.Windows.Forms;
 
@@ -176,6 +177,32 @@ namespace MPF.UI.Core.Windows
             };
         }
 
+        /// <summary>
+        /// Show the disc information window
+        /// </summary>
+        /// <param name="submissionInfo">SubmissionInfo object to display and possibly change</param>
+        /// <returns>Dialog open result</returns>
+        public (bool?, SubmissionInfo?) ShowDiscInformationWindow(SubmissionInfo? submissionInfo)
+        {
+            var discInformationWindow = new DiscInformationWindow(CheckDumpViewModel.Options, submissionInfo)
+            {
+                Focusable = true,
+                Owner = this,
+                ShowActivated = true,
+                ShowInTaskbar = true,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            };
+
+            discInformationWindow.Closed += delegate { this.Activate(); };
+            bool? result = discInformationWindow.ShowDialog();
+
+            // Copy back the submission info changes, if necessary
+            if (result == true)
+                submissionInfo = (discInformationWindow.DiscInformationViewModel.SubmissionInfo.Clone() as SubmissionInfo)!;
+
+            return (result, submissionInfo!);
+        }
+
         #endregion
 
         #region Event Handlers
@@ -185,7 +212,7 @@ namespace MPF.UI.Core.Windows
         /// </summary>
         private void OnCheckDumpClick(object sender, EventArgs e)
         {
-            string? errorMessage = CheckDumpViewModel.CheckDump();
+            string? errorMessage = CheckDumpViewModel.CheckDump(ShowDiscInformationWindow);
             if (string.IsNullOrEmpty(errorMessage))
             {
                 bool? checkAgain = DisplayUserMessage("Check Complete", "The dump has been processed successfully! Would you like to check another dump?", 2, false);

--- a/MPF.UI.Core/Windows/CheckDumpWindow.xaml.cs
+++ b/MPF.UI.Core/Windows/CheckDumpWindow.xaml.cs
@@ -16,12 +16,10 @@ namespace MPF.UI.Core.Windows
     /// </summary>
     public partial class CheckDumpWindow : WindowBase
     {
-
         /// <summary>
         /// Read-only access to the current check dump view model
         /// </summary>
         public CheckDumpViewModel CheckDumpViewModel => DataContext as CheckDumpViewModel ?? new CheckDumpViewModel();
-
 
 #if NET35
 

--- a/MPF.UI.Core/Windows/CheckDumpWindow.xaml.cs
+++ b/MPF.UI.Core/Windows/CheckDumpWindow.xaml.cs
@@ -121,7 +121,7 @@ namespace MPF.UI.Core.Windows
         public void BrowseFile()
         {
             // Get the current path, if possible
-            string currentPath = CheckDumpViewModel.InputPath;
+            string? currentPath = CheckDumpViewModel.InputPath;
             if (string.IsNullOrEmpty(currentPath) && !string.IsNullOrEmpty(CheckDumpViewModel.Options.DefaultOutputPath))
                 currentPath = CheckDumpViewModel.Options.DefaultOutputPath!;
             if (string.IsNullOrEmpty(currentPath))
@@ -185,8 +185,17 @@ namespace MPF.UI.Core.Windows
         /// </summary>
         private void OnCheckDumpClick(object sender, EventArgs e)
         {
-            DisplayUserMessage("Check Complete", "The dump has been processed", 1, false);
-            Close();
+            string? errorMessage = CheckDumpViewModel.CheckDump();
+            if (string.IsNullOrEmpty(errorMessage))
+            {
+                bool? checkAgain = DisplayUserMessage("Check Complete", "The dump has been processed successfully! Would you like to check another dump?", 2, false);
+                if (checkAgain == false)
+                    Close();
+            }
+            else
+            {
+                DisplayUserMessage("Check Failed", errorMessage!, 1, false);
+            }
         }
 
         /// <summary>
@@ -195,23 +204,6 @@ namespace MPF.UI.Core.Windows
         private void OnCancelClick(object sender, EventArgs e)
         {
             Close();
-        }
-
-        /// <summary>
-        /// Handler for SystemTypeComboBox SelectionChanged event
-        /// </summary>
-        public void SystemTypeComboBoxSelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (CheckDumpViewModel.CanExecuteSelectionChanged)
-                CheckDumpViewModel.ChangeSystem();
-        }
-
-        /// <summary>
-        /// Handler for InputPathBrowseButton Click event
-        /// </summary>
-        public void InputPathBrowseButtonClick(object sender, RoutedEventArgs e)
-        {
-            BrowseFile();
         }
 
         /// <summary>
@@ -224,12 +216,13 @@ namespace MPF.UI.Core.Windows
         }
 
         /// <summary>
-        /// Handler for MediaTypeComboBox SelectionChanged event
+        /// Handler for InputPathBrowseButton Click event
         /// </summary>
-        public void MediaTypeComboBoxSelectionChanged(object sender, SelectionChangedEventArgs e)
+        public void InputPathBrowseButtonClick(object sender, RoutedEventArgs e)
         {
+            BrowseFile();
             if (CheckDumpViewModel.CanExecuteSelectionChanged)
-                CheckDumpViewModel.ChangeMediaType();
+                CheckDumpViewModel.ChangeInputPath();
         }
 
         /// <summary>
@@ -239,6 +232,24 @@ namespace MPF.UI.Core.Windows
         {
             if (CheckDumpViewModel.CanExecuteSelectionChanged)
                 CheckDumpViewModel.ChangeInputPath();
+        }
+
+        /// <summary>
+        /// Handler for MediaTypeComboBox SelectionChanged event
+        /// </summary>
+        public void MediaTypeComboBoxSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (CheckDumpViewModel.CanExecuteSelectionChanged)
+                CheckDumpViewModel.ChangeMediaType();
+        }
+
+        /// <summary>
+        /// Handler for SystemTypeComboBox SelectionChanged event
+        /// </summary>
+        public void SystemTypeComboBoxSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (CheckDumpViewModel.CanExecuteSelectionChanged)
+                CheckDumpViewModel.ChangeSystem();
         }
 
         #endregion

--- a/MPF.UI.Core/Windows/CheckDumpWindow.xaml.cs
+++ b/MPF.UI.Core/Windows/CheckDumpWindow.xaml.cs
@@ -1,0 +1,246 @@
+﻿using System;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using MPF.Core.UI.ViewModels;
+using WPFCustomMessageBox;
+using WinForms = System.Windows.Forms;
+
+#pragma warning disable IDE1006 // Naming Styles
+
+namespace MPF.UI.Core.Windows
+{
+    /// <summary>
+    /// Interaction logic for CheckDumpWindow.xaml
+    /// </summary>
+    public partial class CheckDumpWindow : WindowBase
+    {
+
+        /// <summary>
+        /// Read-only access to the current check dump view model
+        /// </summary>
+        public CheckDumpViewModel CheckDumpViewModel => DataContext as CheckDumpViewModel ?? new CheckDumpViewModel();
+
+
+#if NET35
+
+        #region Settings
+
+        private ComboBox? _DumpingProgramComboBox => ItemHelper.FindChild<ComboBox>(this, "DumpingProgramComboBox");
+        private Button? _InputPathBrowseButton => ItemHelper.FindChild<Button>(this, "InputPathBrowseButton");
+        private TextBox? _InputPathTextBox => ItemHelper.FindChild<TextBox>(this, "InputPathTextBox");
+        private ComboBox? _MediaTypeComboBox => ItemHelper.FindChild<ComboBox>(this, "MediaTypeComboBox");
+        private ComboBox? _SystemTypeComboBox => ItemHelper.FindChild<ComboBox>(this, "SystemTypeComboBox");
+
+        #endregion
+
+        #region Controls
+
+        private System.Windows.Controls.Button? _CheckDumpButton => ItemHelper.FindChild<System.Windows.Controls.Button>(this, "CheckDumpButton");
+        private System.Windows.Controls.Button? _CancelButton => ItemHelper.FindChild<System.Windows.Controls.Button>(this, "CancelButton");
+
+        #endregion
+        
+#endif
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public CheckDumpWindow(MainWindow parent)
+        {
+#if NET40_OR_GREATER || NETCOREAPP
+            InitializeComponent();
+#endif
+
+#if NET452_OR_GREATER || NETCOREAPP
+            var chrome = new System.Windows.Shell.WindowChrome
+            {
+                CaptionHeight = 0,
+                ResizeBorderThickness = new Thickness(0),
+            };
+            System.Windows.Shell.WindowChrome.SetWindowChrome(this, chrome);
+#endif
+        }
+
+        /// <summary>
+        /// Handler for CheckDumpWindow OnContentRendered event
+        /// </summary>
+        protected override void OnContentRendered(EventArgs e)
+        {
+            base.OnContentRendered(e);
+
+            // Add the click handlers to the UI
+            AddEventHandlers();
+        }
+
+        #region UI Functionality
+
+        /// <summary>
+        /// Add all event handlers
+        /// </summary>
+        public void AddEventHandlers()
+        {
+            // Main buttons
+#if NET35
+            _CheckDumpButton!.Click += OnCheckDumpClick;
+            _CancelButton!.Click += OnCancelClick;
+#else
+            CheckDumpButton.Click += OnCheckDumpClick;
+            CancelButton.Click += OnCancelClick;
+#endif
+
+            // User Area Click
+#if NET35
+            _InputPathBrowseButton!.Click += InputPathBrowseButtonClick;
+#else
+            InputPathBrowseButton.Click += InputPathBrowseButtonClick;
+#endif
+
+            // User Area SelectionChanged
+#if NET35
+            _SystemTypeComboBox!.SelectionChanged += SystemTypeComboBoxSelectionChanged;
+            _MediaTypeComboBox!.SelectionChanged += MediaTypeComboBoxSelectionChanged;
+            _DumpingProgramComboBox!.SelectionChanged += DumpingProgramComboBoxSelectionChanged;
+#else
+            SystemTypeComboBox.SelectionChanged += SystemTypeComboBoxSelectionChanged;
+            MediaTypeComboBox.SelectionChanged += MediaTypeComboBoxSelectionChanged;
+            DumpingProgramComboBox.SelectionChanged += DumpingProgramComboBoxSelectionChanged;
+#endif
+
+            // User Area TextChanged
+#if NET35
+            _InputPathTextBox!.TextChanged += InputPathTextBoxTextChanged;
+#else
+            InputPathTextBox.TextChanged += InputPathTextBoxTextChanged;
+#endif
+        }
+
+        /// <summary>
+        /// Browse for an input file path
+        /// </summary>
+        public void BrowseFile()
+        {
+            // Get the current path, if possible
+            string currentPath = CheckDumpViewModel.InputPath;
+            if (string.IsNullOrEmpty(currentPath) && !string.IsNullOrEmpty(CheckDumpViewModel.Options.DefaultOutputPath))
+                currentPath = CheckDumpViewModel.Options.DefaultOutputPath!;
+            if (string.IsNullOrEmpty(currentPath))
+                currentPath = AppDomain.CurrentDomain.BaseDirectory!;
+
+            // Get the full directory
+            var directory = Path.GetDirectoryName(Path.GetFullPath(currentPath));
+
+            WinForms.FileDialog fileDialog = new WinForms.OpenFileDialog
+            {
+                InitialDirectory = directory,
+            };
+            WinForms.DialogResult result = fileDialog.ShowDialog();
+
+            if (result == WinForms.DialogResult.OK)
+            {
+                CheckDumpViewModel.InputPath = fileDialog.FileName;
+            }
+        }
+
+        /// <summary>
+        /// Display a user message using a CustomMessageBox
+        /// </summary>
+        /// <param name="title">Title to display to the user</param>
+        /// <param name="message">Message to display to the user</param>
+        /// <param name="optionCount">Number of options to display</param>
+        /// <param name="flag">true for inquiry, false otherwise</param>
+        /// <returns>true for positive, false for negative, null for neutral</returns>
+        public bool? DisplayUserMessage(string title, string message, int optionCount, bool flag)
+        {
+            // Set the correct button style
+            var button = optionCount switch
+            {
+                1 => MessageBoxButton.OK,
+                2 => MessageBoxButton.YesNo,
+                3 => MessageBoxButton.YesNoCancel,
+
+                // This should not happen, but default to "OK"
+                _ => MessageBoxButton.OK,
+            };
+
+            // Set the correct icon
+            MessageBoxImage image = flag ? MessageBoxImage.Question : MessageBoxImage.Exclamation;
+
+            // Display and get the result
+            MessageBoxResult result = CustomMessageBox.Show(this, message, title, button, image);
+            return result switch
+            {
+                MessageBoxResult.OK or MessageBoxResult.Yes => true,
+                MessageBoxResult.No => false,
+                _ => null,
+            };
+        }
+
+        #endregion
+
+        #region Event Handlers
+
+        /// <summary>
+        /// Handler for CheckDumpButton Click event
+        /// </summary>
+        private void OnCheckDumpClick(object sender, EventArgs e)
+        {
+            DisplayUserMessage("Check Complete", "The dump has been processed", 1, false);
+            Close();
+        }
+
+        /// <summary>
+        /// Handler for CancelButtom Click event
+        /// </summary>
+        private void OnCancelClick(object sender, EventArgs e)
+        {
+            Close();
+        }
+
+        /// <summary>
+        /// Handler for SystemTypeComboBox SelectionChanged event
+        /// </summary>
+        public void SystemTypeComboBoxSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (CheckDumpViewModel.CanExecuteSelectionChanged)
+                CheckDumpViewModel.ChangeSystem();
+        }
+
+        /// <summary>
+        /// Handler for InputPathBrowseButton Click event
+        /// </summary>
+        public void InputPathBrowseButtonClick(object sender, RoutedEventArgs e)
+        {
+            BrowseFile();
+        }
+
+        /// <summary>
+        /// Handler for DumpingProgramComboBox SelectionChanged event
+        /// </summary>
+        public void DumpingProgramComboBoxSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (CheckDumpViewModel.CanExecuteSelectionChanged)
+                CheckDumpViewModel.ChangeDumpingProgram();
+        }
+
+        /// <summary>
+        /// Handler for MediaTypeComboBox SelectionChanged event
+        /// </summary>
+        public void MediaTypeComboBoxSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (CheckDumpViewModel.CanExecuteSelectionChanged)
+                CheckDumpViewModel.ChangeMediaType();
+        }
+
+        /// <summary>
+        /// Handler for InputPathTextBox TextChanged event
+        /// </summary>
+        public void InputPathTextBoxTextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (CheckDumpViewModel.CanExecuteSelectionChanged)
+                CheckDumpViewModel.ChangeInputPath();
+        }
+
+        #endregion
+    }
+}

--- a/MPF.UI.Core/Windows/MainWindow.xaml
+++ b/MPF.UI.Core/Windows/MainWindow.xaml
@@ -49,6 +49,11 @@
                               Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
                               Foreground="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
                               Template="{DynamicResource CustomMenuItemTemplate}">
+                            <MenuItem x:Name="CheckDumpMenuItem" Header="_Check Dump" HorizontalAlignment="Left" Width="185"
+                                  Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
+                                  Foreground="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                  Template="{DynamicResource CustomMenuItemTemplate}"
+                                  IsEnabled="{Binding CheckDumpMenuItemEnabled}"/>
                             <MenuItem x:Name="OptionsMenuItem" Header="_Options" HorizontalAlignment="Left" Width="185"
                                   Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
                                   Foreground="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"

--- a/MPF.UI.Core/Windows/MainWindow.xaml.cs
+++ b/MPF.UI.Core/Windows/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ namespace MPF.UI.Core.Windows
         private MenuItem? _AppExitMenuItem => ItemHelper.FindChild<MenuItem>(this, "AppExitMenuItem");
         private MenuItem? _CheckForUpdatesMenuItem => ItemHelper.FindChild<MenuItem>(this, "CheckForUpdatesMenuItem");
         private MenuItem? _DebugViewMenuItem => ItemHelper.FindChild<MenuItem>(this, "DebugViewMenuItem");
+        private MenuItem? _CheckDumpMenuItem => ItemHelper.FindChild<MenuItem>(this, "CheckDumpMenuItem");
         private MenuItem? _OptionsMenuItem => ItemHelper.FindChild<MenuItem>(this, "OptionsMenuItem");
 
         #endregion
@@ -139,12 +140,14 @@ namespace MPF.UI.Core.Windows
             _AppExitMenuItem!.Click += AppExitClick;
             _CheckForUpdatesMenuItem!.Click += CheckForUpdatesClick;
             _DebugViewMenuItem!.Click += DebugViewClick;
+            _CheckDumpMenuItem!.Click += CheckDumpMenuItemClick;
             _OptionsMenuItem!.Click += OptionsMenuItemClick;
 #else
             AboutMenuItem.Click += AboutClick;
             AppExitMenuItem.Click += AppExitClick;
             CheckForUpdatesMenuItem.Click += CheckForUpdatesClick;
             DebugViewMenuItem.Click += DebugViewClick;
+            CheckDumpMenuItem.Click += CheckDumpMenuItemClick;
             OptionsMenuItem.Click += OptionsMenuItemClick;
 #endif
 
@@ -314,6 +317,31 @@ namespace MPF.UI.Core.Windows
         }
 
         /// <summary>
+        /// Show the Check Dump window
+        /// </summary>
+        public void ShowCheckDumpWindow()
+        {
+            // Hide MainWindow while Check GUI is open
+            this.Hide();
+
+            var checkDumpWindow = new CheckDumpWindow(this)
+            {
+                Focusable = true,
+                Owner = this,
+                ShowActivated = true,
+                ShowInTaskbar = true,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            };
+
+            checkDumpWindow.Closed += delegate {
+                // Unhide Main window after Check window has been closed
+                this.Show();
+                this.Activate();
+            };
+            checkDumpWindow.Show();
+        }
+
+        /// <summary>
         /// Show the Options window
         /// </summary>
         public void ShowOptionsWindow(string? title = null)
@@ -385,6 +413,12 @@ namespace MPF.UI.Core.Windows
         /// </summary>
         public void AppExitClick(object sender, RoutedEventArgs e) =>
             Application.Current.Shutdown();
+
+        /// <summary>
+        /// Handler for CheckDumpMenuItem Click event
+        /// </summary>
+        public void CheckDumpMenuItemClick(object sender, RoutedEventArgs e) =>
+            ShowCheckDumpWindow();
 
         /// <summary>
         /// Handler for CheckForUpdatesMenuItem Click event


### PR DESCRIPTION
Creates a new window accessible via Tools -> Check Dump
The window acts as a GUI for MPF.Check functionality, allowing the main MPF UI program to provide an interface for creating submission info for dumps performed outside of MPF such as PSP and GC/Wii dumps.

The MPF.Check options follow whatever the main UI options are set as.
Protection scanning is currently not supported for the Check Dump GUI as you can run protection scanning via the main window.
Some naive checks are performed to disable the "Check Dump" button, and a message box will appear with an error message if MPF.Check failed. On success, the Disc Information Window will appear, followed by a message box asking if you wish to check another dump.

Example screenshot of the Check Dump GUI:
![image](https://github.com/SabreTools/MPF/assets/138427222/5d047d72-a67a-42ad-a654-c999ca259787)


Fixes #466