### PR TITLE
Parse PSX/PS2/KP2 exe date from logs

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -22,6 +22,7 @@
 - Fix information pulling for CleanRip and UIC
 - Add UMD handling for the disc info window
 - Detect Photo CD
+- Parse PSX/PS2/KP2 exe date from logs (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/InfoTool.cs
+++ b/MPF.Core/InfoTool.cs
@@ -503,9 +503,6 @@ namespace MPF.Core
                 .Replace('_', '-')
                 .Replace(".", string.Empty);
 
-            // Some games may have the EXE in a subfolder
-            serial = Path.GetFileName(serial);
-
             // Get the region, if possible
             region = GetPlayStationRegion(exeName);
 

--- a/MPF.Core/InfoTool.cs
+++ b/MPF.Core/InfoTool.cs
@@ -384,6 +384,66 @@ namespace MPF.Core
             return di.Units[0]?.Body?.DiscTypeIdentifier;
         }
 
+        internal static string? GetPlayStationExecutableName(char? driveLetter)
+        {
+            // If there's no drive letter, we can't get exe name
+            if (driveLetter == null)
+                return null;
+
+            // Convert drive letter to drive path
+            string drivePath = driveLetter + ":\\";
+            return GetPlayStationExecutableName(drivePath);
+        }
+
+        internal static string? GetPlayStationExecutableName(string? drivePath)
+        {
+            // If there's no drive path, we can't get exe name
+            if (string.IsNullOrEmpty(drivePath))
+                return null;
+
+            // If the folder no longer exists, we can't get exe name
+            if (!Directory.Exists(drivePath))
+                return null;
+
+            // Get the two paths that we will need to check
+            string psxExePath = Path.Combine(drivePath, "PSX.EXE");
+            string systemCnfPath = Path.Combine(drivePath, "SYSTEM.CNF");
+
+            // Read the CNF file as an INI file
+            var systemCnf = new IniFile(systemCnfPath);
+            string bootValue = string.Empty;
+
+            // PlayStation uses "BOOT" as the key
+            if (systemCnf.ContainsKey("BOOT"))
+                bootValue = systemCnf["BOOT"];
+
+            // PlayStation 2 uses "BOOT2" as the key
+            if (systemCnf.ContainsKey("BOOT2"))
+                bootValue = systemCnf["BOOT2"];
+
+            // If we had any boot value, parse it and get the executable name
+            if (!string.IsNullOrEmpty(bootValue))
+            {
+                var match = Regex.Match(bootValue, @"cdrom.?:\\?(.*)", RegexOptions.Compiled);
+                if (match.Groups.Count > 1)
+                {
+                    string? serial = match.Groups[1].Value;
+
+                    // Some games may have the EXE in a subfolder
+                    serial = Path.GetFileName(serial);
+
+                    return serial;
+                }
+            }
+
+            // If the SYSTEM.CNF value can't be found, try PSX.EXE
+            if (File.Exists(psxExePath))
+                return "PSX.EXE";
+
+            // If neither can be found, we return null
+            return null;
+        }
+
         /// <summary>
         /// Get the EXE date from a PlayStation disc, if possible
         /// </summary>
@@ -400,7 +460,7 @@ namespace MPF.Core
             if (driveLetter == null)
                 return false;
 
-            // If the folder no longer exists, we can't do this part
+            // Convert drive letter to drive path
             string drivePath = driveLetter + ":\\";
             return GetPlayStationExecutableInfo(drivePath, out serial, out region, out date);
         }
@@ -425,54 +485,26 @@ namespace MPF.Core
             if (!Directory.Exists(drivePath))
                 return false;
 
-            // Get the two paths that we will need to check
-            string psxExePath = Path.Combine(drivePath, "PSX.EXE");
-            string systemCnfPath = Path.Combine(drivePath, "SYSTEM.CNF");
+            // Get the executable name
+            string? exeName = GetPlayStationExecutableName(drivePath);
 
-            // Try both of the common paths that contain information
-            string? exeName = null;
-
-            // Read the CNF file as an INI file
-            var systemCnf = new IniFile(systemCnfPath);
-            string bootValue = string.Empty;
-
-            // PlayStation uses "BOOT" as the key
-            if (systemCnf.ContainsKey("BOOT"))
-                bootValue = systemCnf["BOOT"];
-
-            // PlayStation 2 uses "BOOT2" as the key
-            if (systemCnf.ContainsKey("BOOT2"))
-                bootValue = systemCnf["BOOT2"];
-
-            // If we had any boot value, parse it and get the executable name
-            if (!string.IsNullOrEmpty(bootValue))
-            {
-                var match = Regex.Match(bootValue, @"cdrom.?:\\?(.*)", RegexOptions.Compiled);
-                if (match.Groups.Count > 1)
-                {
-                    // EXE name may have a trailing `;` after
-                    // EXE name should always be in all caps
-                    exeName = match.Groups[1].Value
-                        .Split(';')[0]
-                        .ToUpperInvariant();
-
-                    // Serial is most of the EXE name normalized
-                    serial = exeName
-                        .Replace('_', '-')
-                        .Replace(".", string.Empty);
-
-                    // Some games may have the EXE in a subfolder
-                    serial = Path.GetFileName(serial);
-                }
-            }
-
-            // If the SYSTEM.CNF value can't be found, try PSX.EXE
-            if (string.IsNullOrEmpty(exeName) && File.Exists(psxExePath))
-                exeName = "PSX.EXE";
-
-            // If neither can be found, we return false
-            if (string.IsNullOrEmpty(exeName))
+            // If no executable found, we can't do this part
+            if (exeName == null)
                 return false;
+
+            // EXE name may have a trailing `;` after
+            // EXE name should always be in all caps
+            exeName = exeName
+                .Split(';')[0]
+                .ToUpperInvariant();
+
+            // Serial is most of the EXE name normalized
+            serial = exeName
+                .Replace('_', '-')
+                .Replace(".", string.Empty);
+
+            // Some games may have the EXE in a subfolder
+            serial = Path.GetFileName(serial);
 
             // Get the region, if possible
             region = GetPlayStationRegion(exeName);

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -1709,10 +1709,10 @@ namespace MPF.Core.Modules.Redumper
                     // Trim the line for later use
                     line = line.Trim();
 
-                    // The profile is listed in a single line
+                    // The exe date is listed in a single line
                     if (line.StartsWith("EXE date:"))
                     {
-                        // current profile: <discType>
+                        // exe date: yyyy-MM-dd
                         return line.Substring("EXE date: ".Length);
                     }
 

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -413,12 +413,13 @@ namespace MPF.Core.Modules.Redumper
                     break;
 
                 case RedumpSystem.KonamiPython2:
+                    info.CommonDiscInfo!.EXEDateBuildDate = GetEXEDate($"{basePath}.log");
                     if (InfoTool.GetPlayStationExecutableInfo(drive?.Name, out var pythonTwoSerial, out Region? pythonTwoRegion, out var pythonTwoDate))
                     {
                         // Ensure internal serial is pulled from local data
                         info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = pythonTwoSerial ?? string.Empty;
                         info.CommonDiscInfo.Region = info.CommonDiscInfo.Region ?? pythonTwoRegion;
-                        info.CommonDiscInfo.EXEDateBuildDate = pythonTwoDate;
+                        info.CommonDiscInfo.EXEDateBuildDate ??= pythonTwoDate;
                     }
 
                     info.VersionAndEditions!.Version = InfoTool.GetPlayStation2Version(drive?.Name) ?? string.Empty;
@@ -477,12 +478,13 @@ namespace MPF.Core.Modules.Redumper
                     break;
 
                 case RedumpSystem.SonyPlayStation:
+                    info.CommonDiscInfo!.EXEDateBuildDate = GetEXEDate($"{basePath}.log");
                     if (InfoTool.GetPlayStationExecutableInfo(drive?.Name, out var playstationSerial, out Region? playstationRegion, out var playstationDate))
                     {
                         // Ensure internal serial is pulled from local data
                         info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = playstationSerial ?? string.Empty;
                         info.CommonDiscInfo.Region = info.CommonDiscInfo.Region ?? playstationRegion;
-                        info.CommonDiscInfo.EXEDateBuildDate = playstationDate;
+                        info.CommonDiscInfo.EXEDateBuildDate ??= playstationDate;
                     }
 
                     info.CopyProtection!.AntiModchip = GetPlayStationAntiModchipDetected($"{basePath}.log").ToYesNo();
@@ -492,12 +494,13 @@ namespace MPF.Core.Modules.Redumper
                     break;
 
                 case RedumpSystem.SonyPlayStation2:
+                    info.CommonDiscInfo!.EXEDateBuildDate = GetEXEDate($"{basePath}.log");
                     if (InfoTool.GetPlayStationExecutableInfo(drive?.Name, out var playstationTwoSerial, out Region? playstationTwoRegion, out var playstationTwoDate))
                     {
                         // Ensure internal serial is pulled from local data
                         info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = playstationTwoSerial ?? string.Empty;
                         info.CommonDiscInfo.Region = info.CommonDiscInfo.Region ?? playstationTwoRegion;
-                        info.CommonDiscInfo.EXEDateBuildDate = playstationTwoDate;
+                        info.CommonDiscInfo.EXEDateBuildDate ??= playstationTwoDate;
                     }
 
                     info.VersionAndEditions!.Version = InfoTool.GetPlayStation2Version(drive?.Name) ?? string.Empty;
@@ -1683,6 +1686,45 @@ namespace MPF.Core.Modules.Redumper
             {
                 // We don't care what the exception is right now
                 return -1;
+            }
+        }
+
+        /// <summary>
+        /// Get the EXE Date from the log, if possible
+        /// </summary>
+        /// <param name="log">Log file location</param>
+        /// <returns>EXE date if possible, null otherwise</returns>
+        public static string? GetEXEDate(string log)
+        {
+            // If the file doesn't exist, we can't get the info
+            if (!File.Exists(log))
+                return null;
+
+            try
+            {
+                using var sr = File.OpenText(log);
+                var line = sr.ReadLine();
+                while (line != null)
+                {
+                    // Trim the line for later use
+                    line = line.Trim();
+
+                    // The profile is listed in a single line
+                    if (line.StartsWith("EXE date:"))
+                    {
+                        // current profile: <discType>
+                        return line.Substring("EXE date: ".Length);
+                    }
+
+                    line = sr.ReadLine();   
+                }
+
+                return null;
+            }
+            catch
+            {
+                // We don't care what the exception is right now
+                return null;
             }
         }
 


### PR DESCRIPTION
Parses EXE date from DIC and Redumper logs for PSX/PS2/KP2 discs if it exists, falling back to the previous method of MPF reading the date directly if it does not exist in the logs.

Using Redumper with MPF.Check will get the exe date, but DIC with MPF.Check won't because MPF needs to read the system.cnf file from the drive in order to parse exe date from DIC logs.

Fixes #626 