### PR TITLE
Exclude extra tracks when finding disc matches

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -23,6 +23,7 @@
 - Add UMD handling for the disc info window
 - Detect Photo CD
 - Parse PSX/PS2/KP2 exe date from logs (Deterous)
+- Exclude extra tracks when finding disc matches (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/SubmissionInfoTool.cs
+++ b/MPF.Core/SubmissionInfoTool.cs
@@ -544,7 +544,9 @@ namespace MPF.Core
                     || hashData.Contains("(Track 00).bin")
                     || hashData.Contains("(Track 00.2).bin")
                     || hashData.Contains("(Track A).bin")
-                    || hashData.Contains("(Track AA).bin"))
+                    || hashData.Contains("(Track A.2).bin")
+                    || hashData.Contains("(Track AA).bin")
+                    || hashData.Contains("(Track AA.2).bin"))
                 {
                     trackCount--;
                     resultProgress?.Report(Result.Success("Extra track found, skipping!"));


### PR DESCRIPTION
Add cases for A.2 and AA.2
Extra cases or better logic can be added in future if needed.

Fixes #640