### PR TITLE
Verbose Redumper log by default

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -24,6 +24,7 @@
 - Detect Photo CD
 - Parse PSX/PS2/KP2 exe date from logs (Deterous)
 - Exclude extra tracks when finding disc matches (Deterous)
+- Verbose Redumper log by default (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF.Core/Data/Options.cs
+++ b/MPF.Core/Data/Options.cs
@@ -321,7 +321,7 @@ namespace MPF.Core.Data
         /// </summary>
         public bool RedumperEnableVerbose
         {
-            get { return GetBooleanSetting(Settings, "RedumperEnableVerbose", false); }
+            get { return GetBooleanSetting(Settings, "RedumperEnableVerbose", true); }
             set { Settings["RedumperEnableVerbose"] = value.ToString(); }
         }
 


### PR DESCRIPTION
Sets the Redumper verbose flag by default.
Redumper logs will not look any different if no errors occuring during dumping.