### PR TITLE
Fix compiler warning

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -29,6 +29,7 @@
 - Fix build from rushed code
 - Remove `-disc2` from Cleanrip serial
 - Enable Windows builds on Linux and Mac
+- Fix compiler warning (Deterous)
 
 ### 3.0.3 (2023-12-04)
 

--- a/MPF/MPF.csproj
+++ b/MPF/MPF.csproj
@@ -67,9 +67,6 @@
   <ItemGroup Condition="$(TargetFramework.StartsWith(`net2`)) OR $(TargetFramework.StartsWith(`net3`)) OR $(TargetFramework.StartsWith(`net4`))">
     <Reference Include="PresentationFramework.Aero" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith(`netcoreapp`)) OR $(TargetFramework.StartsWith(`net5`)) OR $(TargetFramework.StartsWith(`net6`)) OR $(TargetFramework.StartsWith(`net7`)) OR $(TargetFramework.StartsWith(`net8`))">
-    <Reference Include="PresentationFramework.Aero2" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="BinaryObjectScanner" PrivateAssets="build; analyzers" ExcludeAssets="contentFiles" Version="3.0.2" GeneratePathProperty="true">


### PR DESCRIPTION
Compiler (even [Appveyor](https://ci.appveyor.com/project/mnadareski/mpf/builds/49110150)) currently gives this warning for .NET Core builds:
`warning MSB3243: No way to resolve conflict between "PresentationFramework.Aero2, Version=6.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" and "PresentationFramework.Aero2". Choosing "PresentationFramework.Aero2, Version=6.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `

I'm unsure what is already implicitly pulling PresentationFramework.Aero2, but by removing the redundant reference, this warning goes away (check the [appveyor compiler messages for this build](https://ci.appveyor.com/project/mnadareski/mpf/builds/49123283)).