### PR TITLE
Fix DIC log parsing for SS version

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -2,6 +2,7 @@
 
 - Remove .NET 6 from auto-builds
 - Make Redumper the default for new users
+- Fix DIC log parsing for SS version
 
 ### 3.1.0 (2024-02-06)
 

--- a/MPF.Core/Modules/DiscImageCreator/Parameters.cs
+++ b/MPF.Core/Modules/DiscImageCreator/Parameters.cs
@@ -3720,6 +3720,9 @@ namespace MPF.Core.Modules.DiscImageCreator
             // This flag is needed because recent versions of DIC include security data twice
             bool foundSecuritySectors = false;
 
+            // SS version for all Kreon DIC dumps is v1
+            ssver = "01";
+
             try
             {
                 using var sr = File.OpenText(disc);
@@ -3729,11 +3732,13 @@ namespace MPF.Core.Modules.DiscImageCreator
                     if (line == null)
                         break;
 
-                    // Security Sector version
+                    // XGD version (1 = Xbox, 2 = Xbox360)
+                    /*
                     if (line.StartsWith("Version of challenge table"))
                     {
-                        ssver = line.Split(' ')[4]; // "Version of challenge table: <VER>"
+                        xgdver = line.Split(' ')[4]; // "Version of challenge table: <VER>"
                     }
+                    */
 
                     // Security Sector ranges
                     else if (line.StartsWith("Number of security sector ranges:") && !foundSecuritySectors)
@@ -3808,6 +3813,9 @@ namespace MPF.Core.Modules.DiscImageCreator
             // This flag is needed because recent versions of DIC include security data twice
             bool foundSecuritySectors = false;
 
+            // SS version for all Kreon DIC dumps is v1
+            ssver = "01";
+
             try
             {
                 using var sr = File.OpenText(disc);
@@ -3817,11 +3825,13 @@ namespace MPF.Core.Modules.DiscImageCreator
                     if (line == null)
                         break;
 
-                    // Security Sector version
+                    // XGD version (1 = Xbox, 2 = Xbox360)
+                    /*
                     if (line.StartsWith("Version of challenge table"))
                     {
-                        ssver = line.Split(' ')[4]; // "Version of challenge table: <VER>"
+                        xgdver = line.Split(' ')[4]; // "Version of challenge table: <VER>"
                     }
+                    */
 
                     // Security Sector ranges
                     else if (line.StartsWith("Number of security sector ranges:") && !foundSecuritySectors)


### PR DESCRIPTION
MPF currently parses 
> Version of challenge table: 02

in DIC logs as the SS (security sector) version.

This is actually DIC's way of saying the XGD version (1 = Xbox, 2 = Xbox360): https://github.com/saramibreak/DiscImageCreator/blob/31b4d32082a1ec00cf69e6edb369f982001ac807/DiscImageCreator/execScsiCmdforDVD.cpp#L1959

Instead, the SS version for all Kreon dumps using DIC is 1. Useful SSv2 data is only obtainable by 0800 drives, which are not supported by DIC (or any of MPF's current dumping programs).