### PR TITLE
Hide unavailable dumping programs

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -4,6 +4,7 @@
 - Port build script fixes from BOS
 - Fix double git hash version (feat. Deterous)
 - Readd x86 builds by default
+- Hide unavailable dumping programs (Deterous)
 
 ### 3.1.1 (2024-02-20)
 

--- a/MPF.Core/DumpEnvironment.cs
+++ b/MPF.Core/DumpEnvironment.cs
@@ -150,8 +150,11 @@ namespace MPF.Core
                 InternalProgram.DCDumper => null, // TODO: Create correct parameter type when supported
                 InternalProgram.UmdImageCreator => new Modules.UmdImageCreator.Parameters(parameters) { ExecutablePath = null },
 
+                // If no dumping program found, set to null
+                InternalProgram.NONE => null,
+
                 // This should never happen, but it needs a fallback
-                _ => new Modules.DiscImageCreator.Parameters(parameters) { ExecutablePath = Options.DiscImageCreatorPath },
+                _ => new Modules.Redumper.Parameters(parameters) { ExecutablePath = Options.RedumperPath },
             };
 
             // Set system and type
@@ -183,12 +186,15 @@ namespace MPF.Core
                     InternalProgram.DiscImageCreator => new Modules.DiscImageCreator.Parameters(System, Type, Drive.Name, OutputPath, driveSpeed, Options),
                     InternalProgram.Redumper => new Modules.Redumper.Parameters(System, Type, Drive.Name, OutputPath, driveSpeed, Options),
 
+                    // If no dumping program found, set to null
+                    InternalProgram.NONE => null,
+
                     // This should never happen, but it needs a fallback
-                    _ => new Modules.DiscImageCreator.Parameters(System, Type, Drive.Name, OutputPath, driveSpeed, Options),
+                    _ => new Modules.Redumper.Parameters(System, Type, Drive.Name, OutputPath, driveSpeed, Options),
                 };
 
                 // Generate and return the param string
-                return Parameters.GenerateParameters();
+                return Parameters?.GenerateParameters();
             }
 
             return null;
@@ -281,6 +287,9 @@ namespace MPF.Core
             Func<SubmissionInfo?, (bool?, SubmissionInfo?)>? processUserInfo = null,
             SubmissionInfo? seedInfo = null)
         {
+            if (Parameters == null)
+                return Result.Failure("Error! Current configuration is not supported!");
+
             resultProgress?.Report(Result.Success("Gathering submission information... please wait!"));
 
             // Get the output directory and filename separately


### PR DESCRIPTION
If a dumping program has been deleted from the `Programs/` folder, or it was not bundled with an MPF build, remove it from the list of selectable dumping programs on the main window.
If no programs are found, warn the user.

This is an attempt at a soft solution for #527 whereby support for dumping with DIC remains intact, but at some point in the future, MPF releases can be packaged without bundled DIC, and users who wish to dump with DIC will just need to add it to the `Programs/` folder.

Perhaps something similar needs adding to the Default Dumping Program dropdown in the Options window, but for now it works fine if the default program is not available. Having a default program that doesn't exist (yet) could be a desired option anyway?