### PR TITLE
Pull PS3 Disc Key from redump

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -11,6 +11,7 @@
 - Fix misattributed artifact
 - Update README with current build instructions
 - Opt-in automatic IRD creation after PS3 dump (Deterous)
+- Pull PS3 Disc Key from redump (Deterous)
 
 ### 3.1.1 (2024-02-20)
 

--- a/MPF.Core/SubmissionInfoTool.cs
+++ b/MPF.Core/SubmissionInfoTool.cs
@@ -452,7 +452,7 @@ namespace MPF.Core
                     break;
 
                 case RedumpSystem.SonyPlayStation3:
-                    info.Extras!.DiscKey = options.AddPlaceholders ? Template.RequiredValue : string.Empty;
+                    info.Extras!.DiscKey ??= options.AddPlaceholders ? Template.RequiredValue : string.Empty;
                     info.Extras.DiscID = options.AddPlaceholders ? Template.RequiredValue : string.Empty;
                     break;
 


### PR DESCRIPTION
This enables pulling PS3 disc key from redump, once RedumpLib supports it and MPF's RedumpLib version is updated.