### PR TITLE
Enable LibIRD for all .NET frameworks

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -13,6 +13,7 @@
 - Use SabreTools.Hashing
 - Update to SabreTools.RedumpLib 1.3.5
 - Update packages to latest
+- Enable LibIRD for all .NET frameworks (Deterous)
 
 ### 3.1.2 (2024-02-27)
 

--- a/MPF.Core/Data/Options.cs
+++ b/MPF.Core/Data/Options.cs
@@ -502,15 +502,10 @@ namespace MPF.Core.Data
 
         /// <summary>
         /// Create a PS3 IRD file after dumping PS3 BD-ROM discs
-        /// Always returns false if not compiled with .NET Core 6 or newer
         /// </summary>
         public bool CreateIRDAfterDumping
         {
-#if NET6_0_OR_GREATER
             get { return GetBooleanSetting(Settings, "CreateIRDAfterDumping", false); }
-#else
-            get { return false; }
-#endif
             set { Settings["CreateIRDAfterDumping"] = value.ToString(); }
         }
 

--- a/MPF.Core/DumpEnvironment.cs
+++ b/MPF.Core/DumpEnvironment.cs
@@ -425,7 +425,6 @@ namespace MPF.Core
                     resultProgress?.Report(Result.Failure(deleteResult));
             }
 
-#if NET6_0_OR_GREATER
             // Create PS3 IRD, if required
             if (Options.CreateIRDAfterDumping && System == RedumpSystem.SonyPlayStation3 && Type == MediaType.BluRay)
             {
@@ -436,7 +435,6 @@ namespace MPF.Core
                 else
                     resultProgress?.Report(Result.Failure(deleteResult));
             }
-#endif
 
             resultProgress?.Report(Result.Success("Submission information process complete!"));
             return Result.Success();

--- a/MPF.Core/InfoTool.cs
+++ b/MPF.Core/InfoTool.cs
@@ -1495,7 +1495,6 @@ namespace MPF.Core
             return files;
         }
 
-#if NET6_0_OR_GREATER
         /// <summary>
         /// Create an IRD and write it to the specified output directory with optional filename suffix
         /// </summary>
@@ -1528,7 +1527,12 @@ namespace MPF.Core
                 layerbreak = Tools.ParseLayerbreak(layerbreak);
 
                 // Create Redump-style reproducible IRD
-                LibIRD.ReIRD ird = await Task.Run(() => new LibIRD.ReIRD(isoPath, discKey, layerbreak, uid));
+#if NET40
+                LibIRD.ReIRD ird = await Task.Factory.StartNew(() =>
+#else
+                LibIRD.ReIRD ird = await Task.Run(() =>
+#endif
+                    new LibIRD.ReIRD(isoPath, discKey, layerbreak, uid));
                 if (pic != null)
                     ird.PIC = pic;
                 if (discID != null && ird.DiscID[15] != 0x00)
@@ -1545,7 +1549,6 @@ namespace MPF.Core
                 return (false, "Failed to create IRD");
             }
         }
-#endif
 
         #endregion
 

--- a/MPF.Core/MPF.Core.csproj
+++ b/MPF.Core/MPF.Core.csproj
@@ -46,14 +46,12 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith(`net6`)) OR $(TargetFramework.StartsWith(`net7`)) OR $(TargetFramework.StartsWith(`net8`))">
-    <PackageReference Include="LibIRD" Version="0.7.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="BinaryObjectScanner" PrivateAssets="build; analyzers" ExcludeAssets="contentFiles" Version="3.1.0" GeneratePathProperty="true">
       <IncludeAssets>runtime; compile; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="LibIRD" Version="0.7.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="psxt001z.Library" Version="0.21.0-beta4" />
     <PackageReference Include="SabreTools.Hashing" Version="1.1.4" />

--- a/MPF.Core/UI/ViewModels/CreateIRDViewModel.cs
+++ b/MPF.Core/UI/ViewModels/CreateIRDViewModel.cs
@@ -1046,7 +1046,6 @@ namespace MPF.Core.UI.ViewModels
 
             try
             {
-#if NET6_0_OR_GREATER
                 // Create Redump-style reproducible IRD
                 LibIRD.ReIRD ird = new(InputPath, Key, Layerbreak);
                 if (PIC != null)
@@ -1056,9 +1055,6 @@ namespace MPF.Core.UI.ViewModels
                 ird.Write(outputPath);
                 CreateIRDStatus = "IRD Created Successfully";
                 return string.Empty;
-#else
-                return "LibIRD requires .NET Core 6 or greater.";
-#endif
             }
             catch (Exception e)
             {

--- a/MPF.Core/UI/ViewModels/MainViewModel.cs
+++ b/MPF.Core/UI/ViewModels/MainViewModel.cs
@@ -77,20 +77,6 @@ namespace MPF.Core.UI.ViewModels
         #region Properties
 
         /// <summary>
-        /// Indicates the inability to create IRDs
-        /// </summary>
-        public bool CannotCreateIRD
-        {
-            get => _cannotCreateIRD;
-            set
-            {
-                _cannotCreateIRD = value;
-                TriggerPropertyChanged(nameof(CannotCreateIRD));
-            }
-        }
-        private bool _cannotCreateIRD;
-
-        /// <summary>
         /// Indicates the status of the check dump menu item
         /// </summary>
         public bool CheckDumpMenuItemEnabled
@@ -550,13 +536,7 @@ namespace MPF.Core.UI.ViewModels
 
             OptionsMenuItemEnabled = true;
             CheckDumpMenuItemEnabled = true;
-#if NET6_0_OR_GREATER
             CreateIRDMenuItemEnabled = true;
-            CannotCreateIRD = false;
-#else
-            CreateIRDMenuItemEnabled = false;
-            CannotCreateIRD = true;
-#endif
             SystemTypeComboBoxEnabled = true;
             MediaTypeComboBoxEnabled = true;
             OutputPathTextBoxEnabled = true;
@@ -1297,9 +1277,7 @@ namespace MPF.Core.UI.ViewModels
         {
             OptionsMenuItemEnabled = false;
             CheckDumpMenuItemEnabled = false;
-#if NET6_0_OR_GREATER
             CreateIRDMenuItemEnabled = false;
-#endif
             SystemTypeComboBoxEnabled = false;
             MediaTypeComboBoxEnabled = false;
             OutputPathTextBoxEnabled = false;
@@ -1321,9 +1299,7 @@ namespace MPF.Core.UI.ViewModels
         {
             OptionsMenuItemEnabled = true;
             CheckDumpMenuItemEnabled = true;
-#if NET6_0_OR_GREATER
             CreateIRDMenuItemEnabled = true;
-#endif
             SystemTypeComboBoxEnabled = true;
             MediaTypeComboBoxEnabled = true;
             OutputPathTextBoxEnabled = true;

--- a/MPF.Core/UI/ViewModels/OptionsViewModel.cs
+++ b/MPF.Core/UI/ViewModels/OptionsViewModel.cs
@@ -42,19 +42,6 @@ namespace MPF.Core.UI.ViewModels
         /// <inheritdoc/>
         public event PropertyChangedEventHandler? PropertyChanged;
 
-        /// <summary>
-        /// Used to indicate whether LibIRD is supported
-        /// Whether compiled with .NET Core 6 or greater
-        /// </summary>
-        public static bool CreateIRDSupported
-        {
-#if NET6_0_OR_GREATER
-            get { return true; }
-#else
-            get { return false; }
-#endif
-        }
-
         #endregion
 
         #region Lists

--- a/MPF.UI.Core/Windows/MainWindow.xaml
+++ b/MPF.UI.Core/Windows/MainWindow.xaml
@@ -58,10 +58,6 @@
                                   Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
                                   Foreground="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
                                   Template="{DynamicResource CustomMenuItemTemplate}"
-                                  ToolTip="IRD Creation is only available on .NET Core 6 or newer."
-                                  ToolTipService.InitialShowDelay="0"
-                                  ToolTipService.IsEnabled="{Binding CannotCreateIRD}"
-                                  ToolTipService.ShowOnDisabled="True"
                                   IsEnabled="{Binding CreateIRDMenuItemEnabled}"/>
                             <MenuItem x:Name="OptionsMenuItem" Header="_Options" HorizontalAlignment="Left" Width="185"
                                   Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -263,7 +263,7 @@
                                      />
 
                                 <CheckBox VerticalAlignment="Center" Content="Create PS3 IRD After Dumping"
-                                     IsChecked="{Binding Options.CreateIRDAfterDumping}" IsEnabled="{Binding CreateIRDSupported}"
+                                     IsChecked="{Binding Options.CreateIRDAfterDumping}"
                                      ToolTip="Automatically creates an IRD file after dumping a PS3 disc" Margin="0,4"
                                      />
                             </UniformGrid>


### PR DESCRIPTION
No longer limited to .NET 6
However, IRDs created with frameworks prior to .NET 6 will not be byte-identical due to the different GZipStream compression level used. The contents should be the same though.