### PR TITLE
Fix config access permissions

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -15,6 +15,7 @@
 - Update packages to latest
 - Enable LibIRD for all .NET frameworks (Deterous)
 - Try updating PR check action
+- Fix config access persmission (Deterous)
 
 ### 3.1.2 (2024-02-27)
 

--- a/MPF.Core/Utilities/OptionsLoader.cs
+++ b/MPF.Core/Utilities/OptionsLoader.cs
@@ -272,7 +272,8 @@ namespace MPF.Core.Utilities
             }
 
             var serializer = JsonSerializer.Create();
-            var reader = new StreamReader(ConfigurationPath);
+            var stream = File.Open(ConfigurationPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            var reader = new StreamReader(stream);
             var settings = serializer.Deserialize(reader, typeof(Dictionary<string, string?>)) as Dictionary<string, string?>;
             return new Options(settings);
         }


### PR DESCRIPTION
Allow OptionsLoader to read from the options even if they are currently being written to (primarily by Check UI and Create IRD windows).
This fixes rare crashes when the user is too fast at opening a new window immediately after changing the options.