### PR TITLE
Update LibIRD to 0.9.0

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -18,7 +18,7 @@
 - Fix config access persmission (Deterous)
 - Fix Check UI deadlock (Deterous)
 - Fix formatting output formatting
-- Update LibIRD to 0.8.0 (Deterous)
+- Update LibIRD to 0.9.0 (Deterous)
 
 ### 3.1.2 (2024-02-27)
 

--- a/MPF.Core/MPF.Core.csproj
+++ b/MPF.Core/MPF.Core.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="BinaryObjectScanner" PrivateAssets="build; analyzers" ExcludeAssets="contentFiles" Version="3.1.0" GeneratePathProperty="true">
       <IncludeAssets>runtime; compile; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="LibIRD" Version="0.8.0" />
+    <PackageReference Include="LibIRD" Version="0.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="psxt001z.Library" Version="0.21.0-beta4" />
     <PackageReference Include="SabreTools.Hashing" Version="1.1.4" />


### PR DESCRIPTION
Revisionist history

Fixes another breaking bug. Should be the last update to LibIRD until/unless ST.Compression gets GZipStream support.