### PR TITLE
Fix parameter parsing for `=` symbol

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,3 +1,7 @@
+### WIP (xxxx-xx-xx)
+
+- Fix parameter parsing for `=` symbol (Deterous)
+
 ### 3.1.5 (2024-04-05)
 
 - Handle `.0.physical` files from Redumpers

--- a/MPF.Core/Modules/BaseParameters.cs
+++ b/MPF.Core/Modules/BaseParameters.cs
@@ -994,11 +994,9 @@ namespace MPF.Core.Modules
                 if (!IsFlagSupported(longFlagString))
                     return null;
 
-                string[] commandParts = parts[i].Split('=');
-                if (commandParts.Length != 2)
-                    return null;
+                int loc = parts[i].IndexOf('=');
 
-                string valuePart = commandParts[1];
+                string valuePart = parts[i].Substring(loc + 1);
 
                 this[longFlagString] = true;
                 return valuePart.Trim('"');


### PR DESCRIPTION
Assumes that first instance of `=` symbol in command part is the one delimiting the value
Fixes #686 