### PR TITLE
Custom non-redump Redumper options

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -2,6 +2,7 @@
 
 - Fix parameter parsing for `=` symbol (Deterous)
 - Define better default categories (Deterous)
+- Custom non-redump Redumper options (Deterous)
 
 ### 3.1.5 (2024-04-05)
 

--- a/MPF.Core/Converters/EnumConverter.cs
+++ b/MPF.Core/Converters/EnumConverter.cs
@@ -111,7 +111,44 @@ namespace MPF.Core.Converters
             };
         }
 
-#endregion
+        /// <summary>
+        /// Get the string representation of the RedumperReadMethod enum values
+        /// </summary>
+        /// <param name="method">RedumperReadMethod value to convert</param>
+        /// <returns>String representing the value, if possible</returns>
+        public static string LongName(this RedumperReadMethod? method)
+        {
+            return (method) switch
+            {
+                RedumperReadMethod.D8 => "D8",
+                RedumperReadMethod.BE => "BE",
+                RedumperReadMethod.BE_CDDA => "BE_CDDA",
+
+                RedumperReadMethod.NONE => "Default",
+                _ => "Unknown",
+            };
+        }
+
+        /// <summary>
+        /// Get the string representation of the RedumperSectorOrder enum values
+        /// </summary>
+        /// <param name="order">RedumperSectorOrder value to convert</param>
+        /// <returns>String representing the value, if possible</returns>
+        public static string LongName(this RedumperSectorOrder? order)
+        {
+            return (order) switch
+            {
+                RedumperSectorOrder.DATA_C2_SUB => "DATA_C2_SUB",
+                RedumperSectorOrder.DATA_SUB_C2 => "DATA_SUB_C2",
+                RedumperSectorOrder.DATA_SUB => "DATA_SUB",
+                RedumperSectorOrder.DATA_C2 => "DATA_C2",
+
+                RedumperSectorOrder.NONE => "Default",
+                _ => "Unknown",
+            };
+        }
+
+        #endregion
 
         #region Convert From String
 
@@ -296,6 +333,56 @@ namespace MPF.Core.Converters
                     or "rca videodisc" => MediaType.CED,
 
                 _ => MediaType.NONE,
+            };
+        }
+
+        /// <summary>
+        /// Get the RedumperReadMethod enum value for a given string
+        /// </summary>
+        /// <param name="method">String value to convert</param>
+        /// <returns>RedumperReadMethod represented by the string, if possible</returns>
+        public static RedumperReadMethod ToRedumperReadMethod(string? method)
+        {
+            return (method?.ToLowerInvariant()) switch
+            {
+                "d8" => RedumperReadMethod.D8,
+                "be" => RedumperReadMethod.BE,
+                "be_cdda"
+                    or "be cdda"
+                    or "be-cdda"
+                    or "becdda" => RedumperReadMethod.BE_CDDA,
+
+                _ => RedumperReadMethod.NONE,
+            };
+        }
+
+        /// <summary>
+        /// Get the RedumperSectorOrder enum value for a given string
+        /// </summary>
+        /// <param name="order">String value to convert</param>
+        /// <returns>RedumperSectorOrder represented by the string, if possible</returns>
+        public static RedumperSectorOrder ToRedumperSectorOrder(string? order)
+        {
+            return (order?.ToLowerInvariant()) switch
+            {
+                "data_c2_sub"
+                    or "data c2 sub"
+                    or "data-c2-sub"
+                    or "datac2sub" => RedumperSectorOrder.DATA_C2_SUB,
+                "data_sub_c2"
+                    or "data sub c2"
+                    or "data-sub-c2"
+                    or "datasubc2" => RedumperSectorOrder.DATA_SUB_C2,
+                "data_sub"
+                    or "data sub"
+                    or "data-sub"
+                    or "datasub" => RedumperSectorOrder.DATA_SUB,
+                "data_c2"
+                    or "data c2"
+                    or "data-c2"
+                    or "datac2" => RedumperSectorOrder.DATA_C2,
+
+                _ => RedumperSectorOrder.NONE,
             };
         }
 

--- a/MPF.Core/Data/Enumerations.cs
+++ b/MPF.Core/Data/Enumerations.cs
@@ -51,6 +51,31 @@
     }
 
     /// <summary>
+    /// Drive read method option
+    /// </summary>
+    public enum RedumperReadMethod
+    {
+        NONE = 0,
+
+        BE,
+        D8,
+        BE_CDDA,
+    }
+
+    /// <summary>
+    /// Drive sector order option
+    /// </summary>
+    public enum RedumperSectorOrder
+    {
+        NONE = 0,
+
+        DATA_C2_SUB,
+        DATA_SUB_C2,
+        DATA_SUB,
+        DATA_C2,
+    }
+
+    /// <summary>
     /// Log level for output
     /// </summary>
     public enum LogLevel

--- a/MPF.Core/Data/Options.cs
+++ b/MPF.Core/Data/Options.cs
@@ -326,12 +326,12 @@ namespace MPF.Core.Data
         }
 
         /// <summary>
-        /// Enable BE reading by default with Redumper
+        /// Enable options incompatible with redump submissions
         /// </summary>
-        public bool RedumperUseBEReading
+        public bool RedumperNonRedumpMode
         {
-            get { return GetBooleanSetting(Settings, "RedumperUseBEReading", false); }
-            set { Settings["RedumperUseBEReading"] = value.ToString(); }
+            get { return GetBooleanSetting(Settings, "RedumperNonRedumpMode", false); }
+            set { Settings["RedumperNonRedumpMode"] = value.ToString(); }
         }
 
         /// <summary>
@@ -341,6 +341,38 @@ namespace MPF.Core.Data
         {
             get { return GetBooleanSetting(Settings, "RedumperUseGenericDriveType", false); }
             set { Settings["RedumperUseGenericDriveType"] = value.ToString(); }
+        }
+
+        /// <summary>
+        /// Currently selected default redumper read method
+        /// </summary>
+        public RedumperReadMethod RedumperReadMethod
+        {
+            get
+            {
+                var valueString = GetStringSetting(Settings, "RedumperReadMethod", RedumperReadMethod.NONE.ToString());
+                return EnumConverter.ToRedumperReadMethod(valueString);
+            }
+            set
+            {
+                Settings["RedumperReadMethod"] = value.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Currently selected default redumper sector order
+        /// </summary>
+        public RedumperSectorOrder RedumperSectorOrder
+        {
+            get
+            {
+                var valueString = GetStringSetting(Settings, "RedumperSectorOrder", RedumperSectorOrder.NONE.ToString());
+                return EnumConverter.ToRedumperSectorOrder(valueString);
+            }
+            set
+            {
+                Settings["RedumperSectorOrder"] = value.ToString();
+            }
         }
 
         /// <summary>

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -1098,10 +1098,15 @@ namespace MPF.Core.Modules.Redumper
                 this[FlagStrings.Verbose] = options.RedumperEnableVerbose;
             if (options.RedumperEnableDebug)
                 this[FlagStrings.Debug] = options.RedumperEnableDebug;
-            if (options.RedumperUseBEReading)
+            if (options.RedumperReadMethod != RedumperReadMethod.NONE)
             {
                 this[FlagStrings.DriveReadMethod] = true;
-                DriveReadMethodValue = "BE_CDDA";
+                DriveReadMethodValue = options.RedumperReadMethod.ToString();
+            }
+            if (options.RedumperSectorOrder != RedumperSectorOrder.NONE)
+            {
+                this[FlagStrings.DriveSectorOrder] = true;
+                DriveSectorOrderValue = options.RedumperSectorOrder.ToString();
             }
             if (options.RedumperUseGenericDriveType)
             {

--- a/MPF.Core/UI/ViewModels/OptionsViewModel.cs
+++ b/MPF.Core/UI/ViewModels/OptionsViewModel.cs
@@ -52,6 +52,16 @@ namespace MPF.Core.UI.ViewModels
         public static List<Element<InternalProgram>> InternalPrograms => PopulateInternalPrograms();
 
         /// <summary>
+        /// Current list of supported Redumper read methods
+        /// </summary>
+        public static List<Element<RedumperReadMethod>> RedumperReadMethods => PopulateRedumperReadMethods();
+
+        /// <summary>
+        /// Current list of supported Redumper sector orders
+        /// </summary>
+        public static List<Element<RedumperSectorOrder>> RedumperSectorOrders => PopulateRedumperSectorOrders();
+
+        /// <summary>
         /// Current list of supported system profiles
         /// </summary>
         public static List<RedumpSystemComboBoxItem> Systems => RedumpSystemComboBoxItem.GenerateElements().ToList();
@@ -77,12 +87,30 @@ namespace MPF.Core.UI.ViewModels
         #region Population
 
         /// <summary>
-        /// Get a complete list of  supported internal programs
+        /// Get a complete list of supported internal programs
         /// </summary>
         private static List<Element<InternalProgram>> PopulateInternalPrograms()
         {
             var internalPrograms = new List<InternalProgram> { InternalProgram.Redumper, InternalProgram.DiscImageCreator, InternalProgram.Aaru };
             return internalPrograms.Select(ip => new Element<InternalProgram>(ip)).ToList();
+        }
+
+        /// <summary>
+        /// Get a complete list of supported redumper drive read methods
+        /// </summary>
+        private static List<Element<RedumperReadMethod>> PopulateRedumperReadMethods()
+        {
+            var readMethods = new List<RedumperReadMethod> { RedumperReadMethod.NONE, RedumperReadMethod.D8, RedumperReadMethod.BE, RedumperReadMethod.BE_CDDA };
+            return readMethods.Select(rm => new Element<RedumperReadMethod>(rm)).ToList();
+        }
+
+        /// <summary>
+        /// Get a complete list of supported redumper drive sector orders
+        /// </summary>
+        private static List<Element<RedumperSectorOrder>> PopulateRedumperSectorOrders()
+        {
+            var sectorOrders = new List<RedumperSectorOrder> { RedumperSectorOrder.NONE, RedumperSectorOrder.DATA_C2_SUB, RedumperSectorOrder.DATA_SUB_C2, RedumperSectorOrder.DATA_SUB, RedumperSectorOrder.DATA_C2 };
+            return sectorOrders.Select(so => new Element<RedumperSectorOrder>(so)).ToList();
         }
 
         #endregion
@@ -105,6 +133,17 @@ namespace MPF.Core.UI.ViewModels
 #else
             return await RedumpHttpClient.ValidateCredentials(username, password);
 #endif
+        }
+
+        /// <summary>
+        /// Reset Redumper non-redump options (Read Method, Sector Order, Drive Type)
+        /// </summary>
+        public void NonRedumpModeUnChecked()
+        {
+            Options.RedumperReadMethod = RedumperReadMethod.NONE;
+            Options.RedumperSectorOrder = RedumperSectorOrder.NONE;
+            Options.RedumperUseGenericDriveType = false;
+            TriggerPropertyChanged(nameof(Options));
         }
 
         #endregion

--- a/MPF.UI.Core/ElementConverter.cs
+++ b/MPF.UI.Core/ElementConverter.cs
@@ -16,6 +16,8 @@ namespace MPF.UI.Core
                 DiscCategory discCategory => new Element<DiscCategory>(discCategory),
                 InternalProgram internalProgram => new Element<InternalProgram>(internalProgram),
                 MediaType mediaType => new Element<MediaType>(mediaType),
+                RedumperReadMethod readMethod => new Element<RedumperReadMethod>(readMethod),
+                RedumperSectorOrder sectorOrder => new Element<RedumperSectorOrder>(sectorOrder),
                 RedumpSystem redumpSystem => new RedumpSystemComboBoxItem(redumpSystem),
                 Region region => new Element<Region>(region),
 
@@ -35,6 +37,8 @@ namespace MPF.UI.Core
                 Element<DiscCategory> dcElement => dcElement.Value,
                 Element<InternalProgram> ipElement => ipElement.Value,
                 Element<MediaType> mtElement => mtElement.Value,
+                Element<RedumperReadMethod> rmElement => rmElement.Value,
+                Element<RedumperSectorOrder> soElement => soElement.Value,
                 RedumpSystemComboBoxItem rsElement => rsElement.Value,
                 Element<Region> reValue => reValue.Value,
                 _ => null,

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -426,7 +426,7 @@
                         </GroupBox>
 
                         <GroupBox Margin="5,5,5,5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Header="Redumper">
-                            <UniformGrid Columns="2" Rows="3">
+                            <UniformGrid Columns="2" Rows="5">
                                 <CheckBox VerticalAlignment="Center" Content="Enable Debug Output"
                                           IsChecked="{Binding Options.RedumperEnableDebug}"
                                           ToolTip="Enable debug output in logs" Margin="0,4"
@@ -437,20 +437,32 @@
                                           ToolTip="Enable verbose output in logs" Margin="0,4"
                                 />
 
-                                <CheckBox VerticalAlignment="Center" Content="Enable BE Drive Reading"
-                                          IsChecked="{Binding Options.RedumperUseBEReading}"
-                                          ToolTip="Enable setting drive read method to BE_CDDA by default" Margin="0,4"
-                                />
-
-                                <CheckBox VerticalAlignment="Center" Content="Set Generic Drive Type"
-                                          IsChecked="{Binding Options.RedumperUseGenericDriveType}"
-                                          ToolTip="Enable setting drive type to Generic by default" Margin="0,4"
-                                />
-
                                 <Label Content="Reread Tries:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                                 <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center"
                                          Text="{Binding Options.RedumperRereadCount}"
-                                          ToolTip="Specifies how many rereads are attempted on read error"
+                                         ToolTip="Specifies how many rereads are attempted on read error"
+                                />
+
+                                <CheckBox VerticalAlignment="Center" Content="Non-Redump Options" Click="NonRedumpModeClicked"
+                                          IsChecked="{Binding Options.RedumperNonRedumpMode}"
+                                          ToolTip="Enable non-redump options" Margin="0,4"
+                                />
+
+                                <CheckBox VerticalAlignment="Center" Content="Set Generic Drive Type"
+                                          IsChecked="{Binding Options.RedumperUseGenericDriveType}" IsEnabled="{Binding Options.RedumperNonRedumpMode}"
+                                          ToolTip="Enable setting drive type to Generic by default" Margin="0,4"
+                                />
+
+                                <Label VerticalAlignment="Center" Content="Default Read Method:" HorizontalAlignment="Right" />
+                                <ComboBox x:Name="DefaultRedumperReadMethodComboBox" Height="22" HorizontalAlignment="Left"
+                                          ItemsSource="{Binding RedumperReadMethods}" SelectedItem="{Binding Options.RedumperReadMethod, Converter={StaticResource ElementConverter}, Mode=TwoWay}"
+                                          Style="{DynamicResource CustomComboBoxStyle}" IsEnabled="{Binding Options.RedumperNonRedumpMode}"
+                                />
+
+                                <Label VerticalAlignment="Center" Content="Default Sector Order:" HorizontalAlignment="Right" />
+                                <ComboBox x:Name="DefaultRedumperSectorOrderComboBox" Height="22" HorizontalAlignment="Left"
+                                          ItemsSource="{Binding RedumperSectorOrders}" SelectedItem="{Binding Options.RedumperSectorOrder, Converter={StaticResource ElementConverter}, Mode=TwoWay}"
+                                          Style="{DynamicResource CustomComboBoxStyle}" IsEnabled="{Binding Options.RedumperNonRedumpMode}"
                                 />
                             </UniformGrid>
                         </GroupBox>

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -370,7 +370,7 @@
                                 />
 
                                 <Label Content="Reread Tries:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                                <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center"
+                                <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
                                          Text="{Binding Options.AaruRereadCount}"
                                          ToolTip="Specifies how many rereads are attempted for sector and subchannel errors"
                                 />
@@ -406,19 +406,19 @@
                                 <Label/>  <!-- Empty label for padding -->
 
                                 <Label Content="Multi-Sector Read Value:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                                <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center"
+                                <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
                                           Text="{Binding Options.DICMultiSectorReadValue}" IsEnabled="{Binding Options.DICMultiSectorRead}"
                                           ToolTip="Set the default value for the /mr flag"
                                 />
 
                                 <Label Content="CD Reread Tries:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                                <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center"
+                                <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
                                           Text="{Binding Options.DICRereadCount}"
                                           ToolTip="Specifies how many rereads are attempted on C2 error [CD only]"
                                 />
 
                                 <Label Content="DVD/HD-DVD/BD Reread Tries:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                                <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center"
+                                <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
                                           Text="{Binding Options.DICDVDRereadCount}"
                                           ToolTip="Specifies how many rereads are attempted on read error [DVD/HD-DVD/BD only]"
                                 />
@@ -438,7 +438,7 @@
                                 />
 
                                 <Label Content="Reread Tries:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                                <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center"
+                                <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
                                          Text="{Binding Options.RedumperRereadCount}"
                                          ToolTip="Specifies how many rereads are attempted on read error"
                                 />
@@ -454,13 +454,13 @@
                                 />
 
                                 <Label VerticalAlignment="Center" Content="Default Read Method:" HorizontalAlignment="Right" />
-                                <ComboBox x:Name="DefaultRedumperReadMethodComboBox" Height="22" HorizontalAlignment="Left"
+                                <ComboBox x:Name="DefaultRedumperReadMethodComboBox" Height="22" Width="200" HorizontalAlignment="Left"
                                           ItemsSource="{Binding RedumperReadMethods}" SelectedItem="{Binding Options.RedumperReadMethod, Converter={StaticResource ElementConverter}, Mode=TwoWay}"
                                           Style="{DynamicResource CustomComboBoxStyle}" IsEnabled="{Binding Options.RedumperNonRedumpMode}"
                                 />
 
                                 <Label VerticalAlignment="Center" Content="Default Sector Order:" HorizontalAlignment="Right" />
-                                <ComboBox x:Name="DefaultRedumperSectorOrderComboBox" Height="22" HorizontalAlignment="Left"
+                                <ComboBox x:Name="DefaultRedumperSectorOrderComboBox" Height="22" Width="200" HorizontalAlignment="Left"
                                           ItemsSource="{Binding RedumperSectorOrders}" SelectedItem="{Binding Options.RedumperSectorOrder, Converter={StaticResource ElementConverter}, Mode=TwoWay}"
                                           Style="{DynamicResource CustomComboBoxStyle}" IsEnabled="{Binding Options.RedumperNonRedumpMode}"
                                 />

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml.cs
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml.cs
@@ -214,7 +214,7 @@ namespace MPF.UI.Core.Windows
                 CustomMessageBox.Show(this, message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
         }
 
-#endregion
+        #endregion
 
         #region Event Handlers
 
@@ -223,6 +223,17 @@ namespace MPF.UI.Core.Windows
         /// </summary>
         private void BrowseForPathClick(object sender, EventArgs e) =>
             BrowseForPath(this, sender as System.Windows.Controls.Button);
+
+        /// <summary>
+        /// Alert user of non-redump mode implications
+        /// </summary>
+        private void NonRedumpModeClicked(object sender, EventArgs e)
+        {
+            if (OptionsViewModel.Options.RedumperNonRedumpMode)
+                CustomMessageBox.Show(this, "All logs generated with these options will not be acceptable for Redump submission", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+            else
+                OptionsViewModel.NonRedumpModeUnChecked();
+        }
 
         /// <summary>
         /// Handler for AcceptButton Click event


### PR DESCRIPTION
Currently, MPF UI options allows for Redumper BE_CDDA mode and GENERIC drive type.
These are somewhat arbitrary (e.g. why not also allow BE mode, or other drive types) and more importantly can misinform users who may set these options without knowing that they are not supported for redump submission.

This PR gates GENERIC drive mode behind a new "Non-Redump Mode", as well as extends read method beyond just BE_CDDA, and adds a new sector order option (Fixes #690 )

Preview:
![image](https://github.com/SabreTools/MPF/assets/138427222/fa106cdd-9290-47fc-bc63-bf9199df0cf7)

Checking non-redump options shows a warning:
![image](https://github.com/SabreTools/MPF/assets/138427222/bfe5e546-0835-4b5e-a2a2-ccd15c7986a6)

The advanced Redumper options can now be set.
![image](https://github.com/SabreTools/MPF/assets/138427222/ad71fcae-be94-4da6-9189-3d057c4fae50)

Unchecking Non-Redump Options resets the three options back to their defaults.