### PR TITLE
Option for default Redumper leadin retries

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,3 +1,7 @@
+### WIP (xxxx-xx-xx)
+
+- Option for default Redumper leadin retries (Deterous)
+
 ### 3.1.7 (2024-04-28)
 
 - Critical update to BinaryObjectScanner 3.1.9

--- a/MPF.Core/Data/Options.cs
+++ b/MPF.Core/Data/Options.cs
@@ -326,6 +326,15 @@ namespace MPF.Core.Data
         }
 
         /// <summary>
+        /// Default number of redumper Plextor leadin retries
+        /// </summary>
+        public int RedumperLeadinRetryCount
+        {
+            get { return GetInt32Setting(Settings, "RedumperLeadinRetryCount", 4); }
+            set { Settings["RedumperLeadinRetryCount"] = value.ToString(); }
+        }
+
+        /// <summary>
         /// Enable options incompatible with redump submissions
         /// </summary>
         public bool RedumperNonRedumpMode

--- a/MPF.Core/Data/Options.cs
+++ b/MPF.Core/Data/Options.cs
@@ -321,7 +321,7 @@ namespace MPF.Core.Data
         /// </summary>
         public bool RedumperEnableLeadinRetry
         {
-            get { return GetBooleanSetting(Settings, "RedumperEnableLeadinRetry", true); }
+            get { return GetBooleanSetting(Settings, "RedumperEnableLeadinRetry", false); }
             set { Settings["RedumperEnableLeadinRetry"] = value.ToString(); }
         }
 

--- a/MPF.Core/Data/Options.cs
+++ b/MPF.Core/Data/Options.cs
@@ -317,6 +317,15 @@ namespace MPF.Core.Data
         }
 
         /// <summary>
+        /// Enable Redumper custom lead-in retries for Plextor drives
+        /// </summary>
+        public bool RedumperEnableLeadinRetry
+        {
+            get { return GetBooleanSetting(Settings, "RedumperEnableLeadinRetry", true); }
+            set { Settings["RedumperEnableLeadinRetry"] = value.ToString(); }
+        }
+
+        /// <summary>
         /// Enable verbose output while dumping by default
         /// </summary>
         public bool RedumperEnableVerbose

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -1134,6 +1134,9 @@ namespace MPF.Core.Modules.Redumper
 
             this[FlagStrings.Retries] = true;
             RetriesValue = options.RedumperRereadCount;
+
+            this[FlagStrings.PlextorLeadinRetries] = true;
+            PlextorLeadinRetriesValue = options.RedumperLeadinRetryCount;
         }
 
         /// <inheritdoc/>

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -1135,8 +1135,11 @@ namespace MPF.Core.Modules.Redumper
             this[FlagStrings.Retries] = true;
             RetriesValue = options.RedumperRereadCount;
 
-            this[FlagStrings.PlextorLeadinRetries] = true;
-            PlextorLeadinRetriesValue = options.RedumperLeadinRetryCount;
+            if (options.RedumperEnableLeadinRetry)
+            {
+                this[FlagStrings.PlextorLeadinRetries] = true;
+                PlextorLeadinRetriesValue = options.RedumperLeadinRetryCount;
+            }
         }
 
         /// <inheritdoc/>

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -426,7 +426,7 @@
                         </GroupBox>
 
                         <GroupBox Margin="5,5,5,5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Header="Redumper">
-                            <UniformGrid Columns="2" Rows="6">
+                            <UniformGrid Columns="2" Rows="7">
                                 <CheckBox VerticalAlignment="Center" Content="Enable Debug Output"
                                           IsChecked="{Binding Options.RedumperEnableDebug}"
                                           ToolTip="Enable debug output in logs" Margin="0,4"
@@ -443,9 +443,15 @@
                                          ToolTip="Specifies how many rereads are attempted on read error"
                                 />
 
+								<CheckBox VerticalAlignment="Center" Content="Cstom default Plextor Lead-in retries"
+                                          IsChecked="{Binding Options.RedumperEnableLeadinRetry}"
+                                          ToolTip="Enable custom lead-in retries for Plextor drives" Margin="0,4"
+                                />
+								<Label/><!-- Empty label for padding -->
+
                                 <Label Content="Plextor Lead-in Retries:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                                 <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
-                                         Text="{Binding Options.RedumperLeadinRetryCount}"
+                                         Text="{Binding Options.RedumperLeadinRetryCount}" IsEnabled ="{Binding.Options.RedumperEnableLeadinRetry}"
                                          ToolTip="Specifies how many retries are attempted for lead-in on Plextor drives"
                                 />
 

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -426,7 +426,7 @@
                         </GroupBox>
 
                         <GroupBox Margin="5,5,5,5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Header="Redumper">
-                            <UniformGrid Columns="2" Rows="5">
+                            <UniformGrid Columns="2" Rows="6">
                                 <CheckBox VerticalAlignment="Center" Content="Enable Debug Output"
                                           IsChecked="{Binding Options.RedumperEnableDebug}"
                                           ToolTip="Enable debug output in logs" Margin="0,4"
@@ -441,6 +441,12 @@
                                 <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
                                          Text="{Binding Options.RedumperRereadCount}"
                                          ToolTip="Specifies how many rereads are attempted on read error"
+                                />
+
+                                <Label Content="Plextor Lead-in Retries:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                                <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
+                                         Text="{Binding Options.RedumperLeadinRetryCount}"
+                                         ToolTip="Specifies how many retries are attempted for lead-in on Plextor drives"
                                 />
 
                                 <CheckBox VerticalAlignment="Center" Content="Non-Redump Options" Click="NonRedumpModeClicked"

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -443,7 +443,7 @@
                                          ToolTip="Specifies how many rereads are attempted on read error"
                                 />
 
-								<CheckBox VerticalAlignment="Center" Content="Custom default Plextor Lead-in retries"
+								<CheckBox VerticalAlignment="Center" Content="Set Default Plextor Lead-in Retries"
                                           IsChecked="{Binding Options.RedumperEnableLeadinRetry}"
                                           ToolTip="Enable custom lead-in retries for Plextor drives" Margin="0,4"
                                 />

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -443,7 +443,7 @@
                                          ToolTip="Specifies how many rereads are attempted on read error"
                                 />
 
-								<CheckBox VerticalAlignment="Center" Content="Cstom default Plextor Lead-in retries"
+								<CheckBox VerticalAlignment="Center" Content="Custom default Plextor Lead-in retries"
                                           IsChecked="{Binding Options.RedumperEnableLeadinRetry}"
                                           ToolTip="Enable custom lead-in retries for Plextor drives" Margin="0,4"
                                 />

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -403,7 +403,8 @@
                                           IsChecked="{Binding Options.DICMultiSectorRead}"
                                           ToolTip="Enable the /mr flag for BD drive dumping" Margin="0,4"
                                 />
-                                <Label/>  <!-- Empty label for padding -->
+                                <Label/> 
+								<!-- Empty label for padding -->
 
                                 <Label Content="Multi-Sector Read Value:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                                 <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
@@ -447,7 +448,8 @@
                                           IsChecked="{Binding Options.RedumperEnableLeadinRetry}"
                                           ToolTip="Enable custom lead-in retries for Plextor drives" Margin="0,4"
                                 />
-								<Label/><!-- Empty label for padding -->
+								<Label/>
+								<!-- Empty label for padding -->
 
                                 <Label Content="Plextor Lead-in Retries:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                                 <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -451,7 +451,7 @@
 
                                 <Label Content="Plextor Lead-in Retries:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                                 <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
-                                         Text="{Binding Options.RedumperLeadinRetryCount}" IsEnabled ="{Binding.Options.RedumperEnableLeadinRetry}"
+                                         Text="{Binding Options.RedumperLeadinRetryCount}" IsEnabled ="{Binding Options.RedumperEnableLeadinRetry}"
                                          ToolTip="Specifies how many retries are attempted for lead-in on Plextor drives"
                                 />
 

--- a/MPF.UI.Core/Windows/OptionsWindow.xaml
+++ b/MPF.UI.Core/Windows/OptionsWindow.xaml
@@ -404,7 +404,7 @@
                                           ToolTip="Enable the /mr flag for BD drive dumping" Margin="0,4"
                                 />
                                 <Label/> 
-								<!-- Empty label for padding -->
+                                <!-- Empty label for padding -->
 
                                 <Label Content="Multi-Sector Read Value:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                                 <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
@@ -444,12 +444,12 @@
                                          ToolTip="Specifies how many rereads are attempted on read error"
                                 />
 
-								<CheckBox VerticalAlignment="Center" Content="Set Default Plextor Lead-in Retries"
+                                <CheckBox VerticalAlignment="Center" Content="Set Default Plextor Lead-in Retries"
                                           IsChecked="{Binding Options.RedumperEnableLeadinRetry}"
                                           ToolTip="Enable custom lead-in retries for Plextor drives" Margin="0,4"
                                 />
-								<Label/>
-								<!-- Empty label for padding -->
+                                <Label/>
+                                <!-- Empty label for padding -->
 
                                 <Label Content="Plextor Lead-in Retries:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                                 <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"


### PR DESCRIPTION
Adds a new textbox to set default plextor leadin retries, below the default reread option. Defaults to 4.
Fixes #692 