### PR TITLE
Fix CleanRip not pulling info

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,6 +1,7 @@
 ### WIP (xxxx-xx-xx)
 
 - Update Redumper to build 325
+- Fix CleanRip not pulling info (Deterous)
 
 ### 3.1.8 (2024-05-09)
 

--- a/MPF.Core/Modules/CleanRip/Parameters.cs
+++ b/MPF.Core/Modules/CleanRip/Parameters.cs
@@ -72,10 +72,7 @@ namespace MPF.Core.Modules.CleanRip
 
             // Get the Datafile information
             var datafile = GenerateCleanripDatafile(basePath + ".iso", basePath + "-dumpinfo.txt");
-
-            // ClrMameProData format is only for CDs
-            if (this.Type == MediaType.CDROM)
-                info.TracksAndWriteOffsets!.ClrMameProData = InfoTool.GenerateDatfile(datafile);
+            info.TracksAndWriteOffsets!.ClrMameProData = InfoTool.GenerateDatfile(datafile);
 
             // Get the individual hash data, as per internal
             if (InfoTool.GetISOHashValues(datafile, out long size, out var crc32, out var md5, out var sha1))


### PR DESCRIPTION
MPF since #685 has not been pulling info from redump for CleanRip dumps.
ClrMameProData should always be generated by all modules, even if not CDROM.
#685 gated it incorrectly, the Disc Information Window knows how to deal with ClrMameProData and ISO hashes both being present.