### PR TITLE
Fix XboxOne/XboxSX Filename bug

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -2,6 +2,7 @@
 
 - Update Redumper to build 325
 - Fix CleanRip not pulling info (Deterous)
+- Fix XboxOne/XboxSX Filename bug (Deterous)
 
 ### 3.1.8 (2024-05-09)
 

--- a/MPF.Core/SubmissionInfoTool.cs
+++ b/MPF.Core/SubmissionInfoTool.cs
@@ -378,7 +378,7 @@ namespace MPF.Core
                         string xboxOneMsxcPath = Path.Combine(drive.Name, "MSXC");
                         if (drive != null && Directory.Exists(xboxOneMsxcPath))
                         {
-                            info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Filename] ??= string.Join("\n",
+                            info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Filename] = string.Join("\n",
                                 Directory.GetFiles(xboxOneMsxcPath, "*", SearchOption.TopDirectoryOnly).Select(Path.GetFileName).ToArray());
                         }
                     }
@@ -391,7 +391,7 @@ namespace MPF.Core
                         string xboxSeriesXMsxcPath = Path.Combine(drive.Name, "MSXC");
                         if (drive != null && Directory.Exists(xboxSeriesXMsxcPath))
                         {
-                            info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Filename] ??= string.Join("\n",
+                            info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.Filename] = string.Join("\n",
                                 Directory.GetFiles(xboxSeriesXMsxcPath, "*", SearchOption.TopDirectoryOnly).Select(Path.GetFileName).ToArray());
                         }
                     }


### PR DESCRIPTION
XboxOne/XboxSX has a post-dump error since at least v3.1.6 due to a bug where SiteCode.Filename is not present in the dictionary during null-coalescing check
This fixes it