### PR TITLE
Trim PIC for XboxOne/XboxSX

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -3,6 +3,7 @@
 - Update Redumper to build 325
 - Fix CleanRip not pulling info (Deterous)
 - Fix XboxOne/XboxSX Filename bug (Deterous)
+- Trim PIC for XboxOne/XboxSX (Deterous)
 
 ### 3.1.8 (2024-05-09)
 

--- a/MPF.Core/Modules/BaseParameters.cs
+++ b/MPF.Core/Modules/BaseParameters.cs
@@ -1198,6 +1198,8 @@ namespace MPF.Core.Modules
                 if (trimLength > -1)
                     hex = hex.Substring(0, trimLength);
 
+                // TODO: Check for non-zero values in discarded PIC
+
                 return Regex.Replace(hex, ".{32}", "$0\n", RegexOptions.Compiled);
             }
             catch

--- a/MPF.Core/Modules/DiscImageCreator/Parameters.cs
+++ b/MPF.Core/Modules/DiscImageCreator/Parameters.cs
@@ -497,6 +497,8 @@ namespace MPF.Core.Modules.DiscImageCreator
                         int trimLength = -1;
                         switch (this.System)
                         {
+                            case RedumpSystem.MicrosoftXboxOne:
+                            case RedumpSystem.MicrosoftXboxSeriesXS:
                             case RedumpSystem.SonyPlayStation3:
                             case RedumpSystem.SonyPlayStation4:
                             case RedumpSystem.SonyPlayStation5:

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -376,6 +376,8 @@ namespace MPF.Core.Modules.Redumper
                         int trimLength = -1;
                         switch (this.System)
                         {
+                            case RedumpSystem.MicrosoftXboxOne:
+                            case RedumpSystem.MicrosoftXboxSeriesXS:
                             case RedumpSystem.SonyPlayStation3:
                             case RedumpSystem.SonyPlayStation4:
                             case RedumpSystem.SonyPlayStation5:


### PR DESCRIPTION
XboxOne/XboxSeriesX discs currently have their entire PIC printed in logs. This trims it similar to PS3/4/5 currently are.
I have decided not to add other systems because PC BD-ROMs are rare and BD-Video can be weird.