### PR TITLE
Prefer PlayStation info from Redumper logs

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -11,6 +11,7 @@
 - Remove now-unused Hash enum
 - Use IO implementation of IniFile
 - Add Xbox Backup Creator support to MPF.Check (Deterous)
+- Prefer PlayStation info from Redumper logs (Deterous)
 
 ### 3.1.8 (2024-05-09)
 

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -2106,6 +2106,10 @@ namespace MPF.Core.Modules.Redumper
                     {
                         serial = line.Substring("serial: ".Length).Trim();
                     }
+                    else if (line.StartsWith("version:"))
+                    {
+                        version = line.Substring("version: ".Length).Trim();
+                    }
                     else if (line.StartsWith("firmware:"))
                     {
                         firmware = line.Substring("firmware: ".Length).Trim();

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -424,23 +424,26 @@ namespace MPF.Core.Modules.Redumper
 
                 case RedumpSystem.KonamiPython2:
                     // Get metadata from log if possible
-                    info.CommonDiscInfo!.EXEDateBuildDate = GetEXEDate($"{basePath}.log");
-                    info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
-                    if (!string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
-                        info.CommonDiscInfo.Region = InfoTool.GetPlayStationRegion(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]);
-                    info.VersionAndEditions!.Version = GetDiscVersion($"{basePath}.log") ?? string.Empty;
+                    if (GetPlayStationInfo($"{basePath}.log", out string? kp2EXEDate, out string? kp2Serial, out string? kp2Version, out var _))
+                    {
+                        info.CommonDiscInfo!.EXEDateBuildDate = kp2EXEDate;
+                        info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = kp2Serial ?? string.Empty;
+                        if (!string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                            info.CommonDiscInfo.Region = InfoTool.GetPlayStationRegion(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]);
+                        info.VersionAndEditions!.Version = kp2Version ?? string.Empty;
+                    }
 
                     // Get metadata from drive if not available from log
                     if (InfoTool.GetPlayStationExecutableInfo(drive?.Name, out var pythonTwoSerial, out Region? pythonTwoRegion, out var pythonTwoDate))
                     {
                         // Ensure internal serial is pulled from local data
-                        if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                        if (string.IsNullOrEmpty(info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName]))
                             info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = pythonTwoSerial ?? string.Empty;
                         info.CommonDiscInfo.Region ??= pythonTwoRegion;
                         if (string.IsNullOrEmpty(info.CommonDiscInfo.EXEDateBuildDate))
                             info.CommonDiscInfo.EXEDateBuildDate = pythonTwoDate;
                     }
-                    if (string.IsNullOrEmpty(info.VersionAndEditions.Version))
+                    if (string.IsNullOrEmpty(info.VersionAndEditions!.Version))
                         info.VersionAndEditions.Version = InfoTool.GetPlayStation2Version(drive?.Name) ?? string.Empty;
                     break;
 
@@ -498,16 +501,19 @@ namespace MPF.Core.Modules.Redumper
 
                 case RedumpSystem.SonyPlayStation:
                     // Get metadata from log if possible
-                    info.CommonDiscInfo!.EXEDateBuildDate = GetEXEDate($"{basePath}.log");
-                    info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
-                    if (!string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
-                        info.CommonDiscInfo.Region = InfoTool.GetPlayStationRegion(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]);
+                    if (GetPlayStationInfo($"{basePath}.log", out string? psxEXEDate, out string? psxSerial, out var _, out var _))
+                    {
+                        info.CommonDiscInfo!.EXEDateBuildDate = psxEXEDate;
+                        info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = psxSerial ?? string.Empty;
+                        if (!string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                            info.CommonDiscInfo.Region = InfoTool.GetPlayStationRegion(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]);
+                    }
 
                     // Get metadata from drive if not available from log
                     if (InfoTool.GetPlayStationExecutableInfo(drive?.Name, out var playstationSerial, out Region? playstationRegion, out var playstationDate))
                     {
                         // Ensure internal serial is pulled from local data
-                        if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                        if (string.IsNullOrEmpty(info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName]))
                             info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = playstationSerial ?? string.Empty;
                         info.CommonDiscInfo.Region ??= playstationRegion;
                         if (string.IsNullOrEmpty(info.CommonDiscInfo.EXEDateBuildDate))
@@ -522,36 +528,41 @@ namespace MPF.Core.Modules.Redumper
 
                 case RedumpSystem.SonyPlayStation2:
                     // Get metadata from log if possible
-                    info.CommonDiscInfo!.EXEDateBuildDate = GetEXEDate($"{basePath}.log");
-                    info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
-                    if (!string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
-                        info.CommonDiscInfo.Region = InfoTool.GetPlayStationRegion(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]);
-                    info.VersionAndEditions!.Version = GetDiscVersion($"{basePath}.log") ?? string.Empty;
+                    if (GetPlayStationInfo($"{basePath}.log", out string? ps2EXEDate, out string? ps2Serial, out var ps2Version, out var _))
+                    {
+                        info.CommonDiscInfo!.EXEDateBuildDate = ps2EXEDate;
+                        info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = ps2Serial ?? string.Empty;
+                        if (!string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                            info.CommonDiscInfo.Region = InfoTool.GetPlayStationRegion(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]);
+                        info.VersionAndEditions!.Version = ps2Version ?? string.Empty;
+                    }
 
                     // Get metadata from drive if not available from log
                     if (InfoTool.GetPlayStationExecutableInfo(drive?.Name, out var playstationTwoSerial, out Region? playstationTwoRegion, out var playstationTwoDate))
                     {
                         // Ensure internal serial is pulled from local data
-                        if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                        if (string.IsNullOrEmpty(info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName]))
                             info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = playstationTwoSerial ?? string.Empty;
                         info.CommonDiscInfo.Region = info.CommonDiscInfo.Region ?? playstationTwoRegion;
                         if (string.IsNullOrEmpty(info.CommonDiscInfo.EXEDateBuildDate))
                             info.CommonDiscInfo.EXEDateBuildDate ??= playstationTwoDate;
                     }
-                    if (string.IsNullOrEmpty(info.VersionAndEditions.Version))
+                    if (string.IsNullOrEmpty(info.VersionAndEditions!.Version))
                         info.VersionAndEditions.Version = InfoTool.GetPlayStation2Version(drive?.Name) ?? string.Empty;
                     break;
 
                 case RedumpSystem.SonyPlayStation3:
                     // Get metadata from log if possible
-                    info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
-                    info.VersionAndEditions!.Version = GetDiscVersion($"{basePath}.log") ?? string.Empty;
-                    string? firmwareVersion = GetFirmwareVersion($"{basePath}.log");
+                    if (GetPlayStationInfo($"{basePath}.log", out var _, out string? ps3Serial, out var ps3Version, out string? firmwareVersion))
+                    {
+                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = ps3Serial ?? string.Empty;
+                        info.VersionAndEditions!.Version = ps3Version ?? string.Empty;
+                    }
 
                     // Get metadata from drive if not available from log
-                    if (string.IsNullOrEmpty(info.VersionAndEditions.Version))
+                    if (string.IsNullOrEmpty(info.VersionAndEditions!.Version))
                         info.VersionAndEditions.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
-                    if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                    if (string.IsNullOrEmpty(info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName]))
                         info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
                     firmwareVersion ??= InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
                     if (firmwareVersion != null)
@@ -559,20 +570,26 @@ namespace MPF.Core.Modules.Redumper
                     break;
 
                 case RedumpSystem.SonyPlayStation4:
-                    info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
-                    info.VersionAndEditions!.Version = GetDiscVersion($"{basePath}.log") ?? string.Empty;
+                    if (GetPlayStationInfo($"{basePath}.log", out var _, out string? ps4Serial, out var ps4Version, out var _))
+                    {
+                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = ps4Serial ?? string.Empty;
+                        info.VersionAndEditions!.Version = ps4Version ?? string.Empty;
+                    }
                     if (string.IsNullOrEmpty(info.VersionAndEditions!.Version))
                         info.VersionAndEditions.Version = InfoTool.GetPlayStation4Version(drive?.Name) ?? string.Empty;
-                    if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                    if (string.IsNullOrEmpty(info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName]))
                         info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation4Serial(drive?.Name) ?? string.Empty;
                     break;
 
                 case RedumpSystem.SonyPlayStation5:
-                    info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
-                    info.VersionAndEditions!.Version = GetDiscVersion($"{basePath}.log") ?? string.Empty;
+                    if (GetPlayStationInfo($"{basePath}.log", out var _, out string? ps5Serial, out var ps5Version, out var _))
+                    {
+                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = ps5Serial ?? string.Empty;
+                        info.VersionAndEditions!.Version = ps5Version ?? string.Empty;
+                    }
                     if (string.IsNullOrEmpty(info.VersionAndEditions!.Version))
                         info.VersionAndEditions.Version = InfoTool.GetPlayStation5Version(drive?.Name) ?? string.Empty;
-                    if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                    if (string.IsNullOrEmpty(info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName]))
                         info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation5Serial(drive?.Name) ?? string.Empty;
                     break;
             }
@@ -1586,45 +1603,6 @@ namespace MPF.Core.Modules.Redumper
         }
 
         /// <summary>
-        /// Get the Disc Version from the log, if possible
-        /// </summary>
-        /// <param name="log">Log file location</param>
-        /// <returns>Disc Version if possible, null otherwise</returns>
-        public static string? GetDiscVersion(string log)
-        {
-            // If the file doesn't exist, we can't get the info
-            if (!File.Exists(log))
-                return null;
-
-            try
-            {
-                using var sr = File.OpenText(log);
-                var line = sr.ReadLine();
-                while (line != null)
-                {
-                    // Trim the line for later use
-                    line = line.Trim();
-
-                    // The disc version is listed in a single line
-                    if (line.StartsWith("version:"))
-                    {
-                        // version: 01.00
-                        return line.Substring("version: ".Length);
-                    }
-
-                    line = sr.ReadLine();
-                }
-
-                return null;
-            }
-            catch
-            {
-                // We don't care what the exception is right now
-                return null;
-            }
-        }
-
-        /// <summary>
         /// Get all Volume Identifiers
         /// </summary>
         /// <param name="log">Log file location</param>
@@ -1828,84 +1806,6 @@ namespace MPF.Core.Modules.Redumper
             {
                 // We don't care what the exception is right now
                 return false;
-            }
-        }
-
-        /// <summary>
-        /// Get the EXE Date from the log, if possible
-        /// </summary>
-        /// <param name="log">Log file location</param>
-        /// <returns>EXE date if possible, null otherwise</returns>
-        public static string? GetEXEDate(string log)
-        {
-            // If the file doesn't exist, we can't get the info
-            if (!File.Exists(log))
-                return null;
-
-            try
-            {
-                using var sr = File.OpenText(log);
-                var line = sr.ReadLine();
-                while (line != null)
-                {
-                    // Trim the line for later use
-                    line = line.Trim();
-
-                    // The exe date is listed in a single line
-                    if (line.StartsWith("EXE date:"))
-                    {
-                        // exe date: yyyy-MM-dd
-                        return line.Substring("EXE date: ".Length);
-                    }
-
-                    line = sr.ReadLine();
-        }
-
-                return null;
-            }
-            catch
-            {
-                // We don't care what the exception is right now
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Get the Firmware Version from the log, if possible
-        /// </summary>
-        /// <param name="log">Log file location</param>
-        /// <returns>Firmware Version if possible, null otherwise</returns>
-        public static string? GetFirmwareVersion(string log)
-        {
-            // If the file doesn't exist, we can't get the info
-            if (!File.Exists(log))
-                return null;
-
-            try
-            {
-                using var sr = File.OpenText(log);
-                var line = sr.ReadLine();
-                while (line != null)
-                {
-                    // Trim the line for later use
-                    line = line.Trim();
-
-                    // The disc version is listed in a single line
-                    if (line.StartsWith("firmware:"))
-                    {
-                        // version: 01.00
-                        return line.Substring("firmware: ".Length);
-                    }
-
-                    line = sr.ReadLine();
-                }
-
-                return null;
-            }
-            catch
-            {
-                // We don't care what the exception is right now
-                return null;
             }
         }
 
@@ -2157,6 +2057,71 @@ namespace MPF.Core.Modules.Redumper
             {
                 // We don't care what the exception is right now
                 return null;
+            }
+        }
+
+        /// <summary>
+        /// Get the info from a PlayStation disc, if possible
+        /// </summary>
+        /// <param name="log">Log file location</param>
+        /// <returns>True if section found, null on error</returns>
+        private static bool GetPlayStationInfo(string log, out string? exeDate, out string? serial, out string? version, out string? firmware)
+        {
+            // Set the default values
+            exeDate = null; serial = null; version = null; firmware = null;
+
+            // If the file doesn't exist, we can't get info from it
+            if (!File.Exists(log))
+                return false;
+
+            try
+            {
+                // Fast forward to the PS info line
+                using var sr = File.OpenText(log);
+                string? line;
+                while (!sr.EndOfStream)
+                {
+                    line = sr.ReadLine()?.TrimStart();
+                    if (line?.StartsWith("PSX [") == true ||
+                        line?.StartsWith("PS2 [") == true ||
+                        line?.StartsWith("PS3 [") == true ||
+                        line?.StartsWith("PS4 [") == true ||
+                        line?.StartsWith("PS5 [") == true)
+                        break;
+                }
+                if (sr.EndOfStream)
+                    return false;
+
+                while (!sr.EndOfStream)
+                {
+                    line = sr.ReadLine()?.TrimStart();
+                    if (line == null)
+                        break;
+
+                    if (line.StartsWith("EXE date:"))
+                    {
+                        exeDate = line.Substring("EXE date: ".Length).Trim();
+                    }
+                    else if (line.StartsWith("serial:"))
+                    {
+                        serial = line.Substring("serial: ".Length).Trim();
+                    }
+                    else if (line.StartsWith("firmware:"))
+                    {
+                        region = line.Substring("firmware: ".Length).Trim();
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                return true;
+            }
+            catch
+            {
+                // We don't care what the exception is right now
+                return false;
             }
         }
 
@@ -2487,45 +2452,6 @@ namespace MPF.Core.Modules.Redumper
                 }
 
                 return headerString.TrimEnd('\n');
-            }
-            catch
-            {
-                // We don't care what the exception is right now
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Get the Serial from the log, if possible
-        /// </summary>
-        /// <param name="log">Log file location</param>
-        /// <returns>Serial if possible, null otherwise</returns>
-        public static string? GetSerial(string log)
-        {
-            // If the file doesn't exist, we can't get the info
-            if (!File.Exists(log))
-                return null;
-
-            try
-            {
-                using var sr = File.OpenText(log);
-                var line = sr.ReadLine();
-                while (line != null)
-                {
-                    // Trim the line for later use
-                    line = line.Trim();
-
-                    // The serial is listed in a single line
-                    if (line.StartsWith("serial:"))
-                    {
-                        // serial: SLES-12345
-                        return line.Substring("serial: ".Length);
-                    }
-
-                    line = sr.ReadLine();
-                }
-
-                return null;
             }
             catch
             {

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -2108,7 +2108,7 @@ namespace MPF.Core.Modules.Redumper
                     }
                     else if (line.StartsWith("firmware:"))
                     {
-                        region = line.Substring("firmware: ".Length).Trim();
+                        firmware = line.Substring("firmware: ".Length).Trim();
                     }
                     else
                     {

--- a/MPF.Core/Modules/Redumper/Parameters.cs
+++ b/MPF.Core/Modules/Redumper/Parameters.cs
@@ -423,16 +423,25 @@ namespace MPF.Core.Modules.Redumper
                     break;
 
                 case RedumpSystem.KonamiPython2:
+                    // Get metadata from log if possible
                     info.CommonDiscInfo!.EXEDateBuildDate = GetEXEDate($"{basePath}.log");
+                    info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
+                    if (!string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                        info.CommonDiscInfo.Region = InfoTool.GetPlayStationRegion(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]);
+                    info.VersionAndEditions!.Version = GetDiscVersion($"{basePath}.log") ?? string.Empty;
+
+                    // Get metadata from drive if not available from log
                     if (InfoTool.GetPlayStationExecutableInfo(drive?.Name, out var pythonTwoSerial, out Region? pythonTwoRegion, out var pythonTwoDate))
                     {
                         // Ensure internal serial is pulled from local data
-                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = pythonTwoSerial ?? string.Empty;
-                        info.CommonDiscInfo.Region = info.CommonDiscInfo.Region ?? pythonTwoRegion;
-                        info.CommonDiscInfo.EXEDateBuildDate ??= pythonTwoDate;
+                        if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                            info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = pythonTwoSerial ?? string.Empty;
+                        info.CommonDiscInfo.Region ??= pythonTwoRegion;
+                        if (string.IsNullOrEmpty(info.CommonDiscInfo.EXEDateBuildDate))
+                            info.CommonDiscInfo.EXEDateBuildDate = pythonTwoDate;
                     }
-
-                    info.VersionAndEditions!.Version = InfoTool.GetPlayStation2Version(drive?.Name) ?? string.Empty;
+                    if (string.IsNullOrEmpty(info.VersionAndEditions.Version))
+                        info.VersionAndEditions.Version = InfoTool.GetPlayStation2Version(drive?.Name) ?? string.Empty;
                     break;
 
                 case RedumpSystem.MicrosoftXbox:
@@ -488,13 +497,21 @@ namespace MPF.Core.Modules.Redumper
                     break;
 
                 case RedumpSystem.SonyPlayStation:
+                    // Get metadata from log if possible
                     info.CommonDiscInfo!.EXEDateBuildDate = GetEXEDate($"{basePath}.log");
+                    info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
+                    if (!string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                        info.CommonDiscInfo.Region = InfoTool.GetPlayStationRegion(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]);
+
+                    // Get metadata from drive if not available from log
                     if (InfoTool.GetPlayStationExecutableInfo(drive?.Name, out var playstationSerial, out Region? playstationRegion, out var playstationDate))
                     {
                         // Ensure internal serial is pulled from local data
-                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = playstationSerial ?? string.Empty;
-                        info.CommonDiscInfo.Region = info.CommonDiscInfo.Region ?? playstationRegion;
-                        info.CommonDiscInfo.EXEDateBuildDate ??= playstationDate;
+                        if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                            info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = playstationSerial ?? string.Empty;
+                        info.CommonDiscInfo.Region ??= playstationRegion;
+                        if (string.IsNullOrEmpty(info.CommonDiscInfo.EXEDateBuildDate))
+                            info.CommonDiscInfo.EXEDateBuildDate = playstationDate;
                     }
 
                     info.CopyProtection!.AntiModchip = GetPlayStationAntiModchipDetected($"{basePath}.log").ToYesNo();
@@ -504,34 +521,59 @@ namespace MPF.Core.Modules.Redumper
                     break;
 
                 case RedumpSystem.SonyPlayStation2:
+                    // Get metadata from log if possible
                     info.CommonDiscInfo!.EXEDateBuildDate = GetEXEDate($"{basePath}.log");
+                    info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
+                    if (!string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                        info.CommonDiscInfo.Region = InfoTool.GetPlayStationRegion(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]);
+                    info.VersionAndEditions!.Version = GetDiscVersion($"{basePath}.log") ?? string.Empty;
+
+                    // Get metadata from drive if not available from log
                     if (InfoTool.GetPlayStationExecutableInfo(drive?.Name, out var playstationTwoSerial, out Region? playstationTwoRegion, out var playstationTwoDate))
                     {
                         // Ensure internal serial is pulled from local data
-                        info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = playstationTwoSerial ?? string.Empty;
+                        if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                            info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = playstationTwoSerial ?? string.Empty;
                         info.CommonDiscInfo.Region = info.CommonDiscInfo.Region ?? playstationTwoRegion;
-                        info.CommonDiscInfo.EXEDateBuildDate ??= playstationTwoDate;
+                        if (string.IsNullOrEmpty(info.CommonDiscInfo.EXEDateBuildDate))
+                            info.CommonDiscInfo.EXEDateBuildDate ??= playstationTwoDate;
                     }
-
-                    info.VersionAndEditions!.Version = InfoTool.GetPlayStation2Version(drive?.Name) ?? string.Empty;
+                    if (string.IsNullOrEmpty(info.VersionAndEditions.Version))
+                        info.VersionAndEditions.Version = InfoTool.GetPlayStation2Version(drive?.Name) ?? string.Empty;
                     break;
 
                 case RedumpSystem.SonyPlayStation3:
-                    info.VersionAndEditions!.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
-                    info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
-                    string? firmwareVersion = InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
+                    // Get metadata from log if possible
+                    info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
+                    info.VersionAndEditions!.Version = GetDiscVersion($"{basePath}.log") ?? string.Empty;
+                    string? firmwareVersion = GetFirmwareVersion($"{basePath}.log");
+
+                    // Get metadata from drive if not available from log
+                    if (string.IsNullOrEmpty(info.VersionAndEditions.Version))
+                        info.VersionAndEditions.Version = InfoTool.GetPlayStation3Version(drive?.Name) ?? string.Empty;
+                    if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                        info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation3Serial(drive?.Name) ?? string.Empty;
+                    firmwareVersion ??= InfoTool.GetPlayStation3FirmwareVersion(drive?.Name);
                     if (firmwareVersion != null)
-                        info.CommonDiscInfo!.ContentsSpecialFields![SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
+                        info.CommonDiscInfo.ContentsSpecialFields![SiteCode.Patches] = $"PS3 Firmware {firmwareVersion}";
                     break;
 
                 case RedumpSystem.SonyPlayStation4:
-                    info.VersionAndEditions!.Version = InfoTool.GetPlayStation4Version(drive?.Name) ?? string.Empty;
-                    info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation4Serial(drive?.Name) ?? string.Empty;
+                    info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
+                    info.VersionAndEditions!.Version = GetDiscVersion($"{basePath}.log") ?? string.Empty;
+                    if (string.IsNullOrEmpty(info.VersionAndEditions!.Version))
+                        info.VersionAndEditions.Version = InfoTool.GetPlayStation4Version(drive?.Name) ?? string.Empty;
+                    if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                        info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation4Serial(drive?.Name) ?? string.Empty;
                     break;
 
                 case RedumpSystem.SonyPlayStation5:
-                    info.VersionAndEditions!.Version = InfoTool.GetPlayStation5Version(drive?.Name) ?? string.Empty;
-                    info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation5Serial(drive?.Name) ?? string.Empty;
+                    info.CommonDiscInfo!.CommentsSpecialFields![SiteCode.InternalSerialName] = GetSerial($"{basePath}.log") ?? string.Empty;
+                    info.VersionAndEditions!.Version = GetDiscVersion($"{basePath}.log") ?? string.Empty;
+                    if (string.IsNullOrEmpty(info.VersionAndEditions!.Version))
+                        info.VersionAndEditions.Version = InfoTool.GetPlayStation5Version(drive?.Name) ?? string.Empty;
+                    if (string.IsNullOrEmpty(info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName]))
+                        info.CommonDiscInfo.CommentsSpecialFields![SiteCode.InternalSerialName] = InfoTool.GetPlayStation5Serial(drive?.Name) ?? string.Empty;
                     break;
             }
 
@@ -1544,6 +1586,45 @@ namespace MPF.Core.Modules.Redumper
         }
 
         /// <summary>
+        /// Get the Disc Version from the log, if possible
+        /// </summary>
+        /// <param name="log">Log file location</param>
+        /// <returns>Disc Version if possible, null otherwise</returns>
+        public static string? GetDiscVersion(string log)
+        {
+            // If the file doesn't exist, we can't get the info
+            if (!File.Exists(log))
+                return null;
+
+            try
+            {
+                using var sr = File.OpenText(log);
+                var line = sr.ReadLine();
+                while (line != null)
+                {
+                    // Trim the line for later use
+                    line = line.Trim();
+
+                    // The disc version is listed in a single line
+                    if (line.StartsWith("version:"))
+                    {
+                        // version: 01.00
+                        return line.Substring("version: ".Length);
+                    }
+
+                    line = sr.ReadLine();
+                }
+
+                return null;
+            }
+            catch
+            {
+                // We don't care what the exception is right now
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Get all Volume Identifiers
         /// </summary>
         /// <param name="log">Log file location</param>
@@ -1775,6 +1856,45 @@ namespace MPF.Core.Modules.Redumper
                     {
                         // exe date: yyyy-MM-dd
                         return line.Substring("EXE date: ".Length);
+                    }
+
+                    line = sr.ReadLine();
+        }
+
+                return null;
+            }
+            catch
+            {
+                // We don't care what the exception is right now
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Get the Firmware Version from the log, if possible
+        /// </summary>
+        /// <param name="log">Log file location</param>
+        /// <returns>Firmware Version if possible, null otherwise</returns>
+        public static string? GetFirmwareVersion(string log)
+        {
+            // If the file doesn't exist, we can't get the info
+            if (!File.Exists(log))
+                return null;
+
+            try
+            {
+                using var sr = File.OpenText(log);
+                var line = sr.ReadLine();
+                while (line != null)
+                {
+                    // Trim the line for later use
+                    line = line.Trim();
+
+                    // The disc version is listed in a single line
+                    if (line.StartsWith("firmware:"))
+                    {
+                        // version: 01.00
+                        return line.Substring("firmware: ".Length);
                     }
 
                     line = sr.ReadLine();
@@ -2367,6 +2487,45 @@ namespace MPF.Core.Modules.Redumper
                 }
 
                 return headerString.TrimEnd('\n');
+            }
+            catch
+            {
+                // We don't care what the exception is right now
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Get the Serial from the log, if possible
+        /// </summary>
+        /// <param name="log">Log file location</param>
+        /// <returns>Serial if possible, null otherwise</returns>
+        public static string? GetSerial(string log)
+        {
+            // If the file doesn't exist, we can't get the info
+            if (!File.Exists(log))
+                return null;
+
+            try
+            {
+                using var sr = File.OpenText(log);
+                var line = sr.ReadLine();
+                while (line != null)
+                {
+                    // Trim the line for later use
+                    line = line.Trim();
+
+                    // The serial is listed in a single line
+                    if (line.StartsWith("serial:"))
+                    {
+                        // serial: SLES-12345
+                        return line.Substring("serial: ".Length);
+                    }
+
+                    line = sr.ReadLine();
+                }
+
+                return null;
             }
             catch
             {


### PR DESCRIPTION
Currently, MPF requires the drive to be available to get PlayStation info such as internal serial and version.
This change parses PlayStation info from the redumper log first and foremost, falling back to the drive if the data is not available.
This will also be forward-compatible for any future redumper versions that support PS3/4/5 metadata. 