### PR TITLE
Fix incorrect matching disc found

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -174,6 +174,7 @@
 - Handle Redumper .asus files
 - Handle Redumper .atip and .pma files
 - Simplify DIC DMI location finding
+- Fix incorrect matching disc found (Deterous)
 
 ### 3.1.9a (2024-05-21)
 

--- a/MPF.Frontend/Tools/SubmissionGenerator.cs
+++ b/MPF.Frontend/Tools/SubmissionGenerator.cs
@@ -248,7 +248,7 @@ namespace MPF.Frontend.Tools
                 }
 
                 // Ensure that all tracks are found
-                allFound &= fullyMatchedIDs.Count > 0
+                allFound &= fullyMatchedIDs.Count > 0;
             }
 
             // If we don't have any matches but we have a universal hash

--- a/MPF.Frontend/Tools/SubmissionGenerator.cs
+++ b/MPF.Frontend/Tools/SubmissionGenerator.cs
@@ -233,9 +233,6 @@ namespace MPF.Frontend.Tools
                 else
                     resultProgress?.Report(ResultEventArgs.Failure(result));
 
-                // Ensure that all tracks are found
-                allFound &= singleFound;
-
                 // If we found a track, only keep track of distinct found tracks
                 if (singleFound && foundIds != null)
                 {
@@ -249,6 +246,9 @@ namespace MPF.Frontend.Tools
                 {
                     fullyMatchedIDs = [];
                 }
+
+                // Ensure that all tracks are found
+                allFound &= fullyMatchedIDs.Count > 0
             }
 
             // If we don't have any matches but we have a universal hash


### PR DESCRIPTION
Ensures that a disc is not detected as in redump if all tracks are in redump but they're not all the same disc ID.

Fixes #708 
