### PR TITLE
Fix parameters after extension change

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -38,6 +38,7 @@
 - Bring Check and CLI in parity with param processing
 - Remove now-unncessary names
 - Don't set MediaType if parameters ambiguous
+- Fix parameters after extension change
 
 ### 3.2.0 (2024-06-20)
 

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -740,7 +740,10 @@ namespace MPF.Frontend.ViewModels
         {
             VerboseLogLn($"Changed dumping program to: {((InternalProgram?)this.CurrentProgram).LongName()}");
             EnsureDiscInformation();
+            // New output name depends on new environment
             GetOutputNames(false);
+            // New environment depends on new output name
+            EnsureDiscInformation();
         }
 
         /// <summary>


### PR DESCRIPTION
Catch 22 with output name relying on new environment and new environment using output name.

Fixes #716