### PR TITLE
Ensure manufacturer files starting from 0 are zipped in redumper DVD …

### DIFF
--- a/MPF.Processors/Redumper.cs
+++ b/MPF.Processors/Redumper.cs
@@ -459,9 +459,6 @@ namespace MPF.Processors
                         new($"{baseFilename}.1.manufacturer", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "manufacturer_1"),
-                        new($"{baseFilename}.2.manufacturer", OutputFileFlags.Binary
-                            | OutputFileFlags.Zippable,
-                            "manufacturer_2"),
                         new([$"{baseFilename}.physical", $"{baseFilename}.0.physical"], OutputFileFlags.Required
                             | OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
@@ -469,9 +466,6 @@ namespace MPF.Processors
                         new($"{baseFilename}.1.physical", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "physical_1"),
-                        new($"{baseFilename}.2.physical", OutputFileFlags.Binary
-                            | OutputFileFlags.Zippable,
-                            "physical_2"),
                         new($"{baseFilename}.security", System.IsXGD()
                             ? OutputFileFlags.Required | OutputFileFlags.Binary | OutputFileFlags.Zippable
                             : OutputFileFlags.Binary | OutputFileFlags.Zippable,
@@ -519,6 +513,9 @@ namespace MPF.Processors
                         new($"{baseFilename}.2.physical", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "physical_2"),
+                        new($"{baseFilename}.3.physical", OutputFileFlags.Binary
+                            | OutputFileFlags.Zippable,
+                            "physical_3"),
                         new($"{baseFilename}.skeleton", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "skeleton"),

--- a/MPF.Processors/Redumper.cs
+++ b/MPF.Processors/Redumper.cs
@@ -452,8 +452,11 @@ namespace MPF.Processors
                             "log"),
                         new CustomOutputFile($"{baseFilename}.log", OutputFileFlags.Required,
                             DatfileExists),
-                        new([$"{baseFilename}.manufacturer", $"{baseFilename}.1.manufacturer"], OutputFileFlags.Required
+                        new([$"{baseFilename}.manufacturer", $"{baseFilename}.0.manufacturer"], OutputFileFlags.Required
                             | OutputFileFlags.Binary
+                            | OutputFileFlags.Zippable,
+                            "manufacturer_0"),
+                        new($"{baseFilename}.1.manufacturer", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "manufacturer_1"),
                         new($"{baseFilename}.2.manufacturer", OutputFileFlags.Binary


### PR DESCRIPTION
Dual-layer ps2 DVDs (at a minimum) produce a foo.0.manufacturer file in addition to foo.1.manufacturer. This change ensures that 0-file is counted among the logs and compressed when "Compress Log Files" is checked

Fixes #746 