### PR TITLE
Add _drive.txt file to GetOutputFiles for UmdImageCreator

### DIFF
--- a/MPF.Processors/UmdImageCreator.cs
+++ b/MPF.Processors/UmdImageCreator.cs
@@ -90,6 +90,10 @@ namespace MPF.Processors
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,
                             "disc"),
+                        new($"{baseFilename}_drive.txt", OutputFileFlags.Required
+                            | OutputFileFlags.Artifact
+                            | OutputFileFlags.Zippable,
+                            "disc"),
                         new($"{baseFilename}_mainError.txt", OutputFileFlags.Required
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,

--- a/MPF.Processors/UmdImageCreator.cs
+++ b/MPF.Processors/UmdImageCreator.cs
@@ -90,8 +90,7 @@ namespace MPF.Processors
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,
                             "disc"),
-                        new($"{baseFilename}_drive.txt", OutputFileFlags.Required
-                            | OutputFileFlags.Artifact
+                        new($"{baseFilename}_drive.txt", OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,
                             "disc"),
                         new($"{baseFilename}_mainError.txt", OutputFileFlags.Required

--- a/MPF.Processors/UmdImageCreator.cs
+++ b/MPF.Processors/UmdImageCreator.cs
@@ -92,7 +92,7 @@ namespace MPF.Processors
                             "disc"),
                         new($"{baseFilename}_drive.txt", OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,
-                            "disc"),
+                            "drive"),
                         new($"{baseFilename}_mainError.txt", OutputFileFlags.Required
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,


### PR DESCRIPTION
Current WIP (not stable) isn't zipping the _drive log file from UmdImageCreator, this PR just adds it back to the list