### PR TITLE
Fix fully matching when multiple matches found

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,6 +1,7 @@
 ### WIP (xxxx-xx-xx)
 
 - Update Redumper to build 438
+- Fix fully matching when multiple matches found
 
 ### 3.2.3 (2024-11-06)
 

--- a/MPF.Frontend/Tools/SubmissionGenerator.cs
+++ b/MPF.Frontend/Tools/SubmissionGenerator.cs
@@ -236,7 +236,7 @@ namespace MPF.Frontend.Tools
                 foundIdSets.Add(foundIds?.ToArray() ?? []);
 
                 // Ensure that all tracks are found
-                allFound &= (foundIds != null && foundIds.Count == 1);
+                allFound &= (foundIds != null && foundIds.Count >= 1);
             }
 
             // If all tracks were found, check if there are any fully-matched IDs


### PR DESCRIPTION
Whenever an entry that is in redump has the following occur:
`Multiple matches found for aa64beff052e53741bba9c2f10aa781d05c96e38`
i.e. multiple IDs are found for a track, MPF flags the dump as a non-fully-matching ID.

This fixes it.