### PR TITLE
Fix PIC parser

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -12,6 +12,7 @@
 - Add Track 0/00/A/AA to Generic
 - Add IMA extension for floppy disks
 - Remove usages of `this.` from themes
+- Fix PIC parser
 
 ### 3.2.3 (2024-11-06)
 

--- a/MPF.Processors/ProcessingTool.cs
+++ b/MPF.Processors/ProcessingTool.cs
@@ -745,7 +745,7 @@ namespace MPF.Processors
             if (string.IsNullOrEmpty(inputPIC))
                 return null;
 
-            string cleanPIC = inputPIC!.Trim().Replace("\n", string.Empty);
+            string cleanPIC = inputPIC!.Trim().Replace("\n", string.Empty).Replace("\r", string.Empty);
 
             if (cleanPIC.Length < 230)
                 return null;


### PR DESCRIPTION
Currently copy-pasting the PIC from redump.org does not work as the parser only removes the \n character
This fixes it to remove both \n and \r