### PR TITLE
Don't add trailing spaces to BCA output

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -27,6 +27,7 @@
 - Version gate remaining Linq statements
 - Cleanup CleanSS check
 - Fix PS3 firmware version being omitted
+- Don't add trailing spaces to BCA output
 
 ### 3.2.3 (2024-11-06)
 

--- a/MPF.Processors/CleanRip.cs
+++ b/MPF.Processors/CleanRip.cs
@@ -177,7 +177,7 @@ namespace MPF.Processors
                 var bca = new StringBuilder();
                 for (int i = 0; i < hex.Length; i++)
                 {
-                    bca.Append(input[i]);
+                    bca.Append(hex[i]);
                     if ((i + 1) % 32 == 0)
                         bca.AppendLine();
                     else if ((i + 1) % 4 == 0)

--- a/MPF.Processors/CleanRip.cs
+++ b/MPF.Processors/CleanRip.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
+using System.Text;
 using SabreTools.Hashing;
 using SabreTools.Models.Logiqx;
 using SabreTools.RedumpLib;
@@ -174,7 +174,7 @@ namespace MPF.Processors
                     return null;
 
                 // Separate into blocks of 4 hex digits and newlines
-                bca = new StringBuilder();
+                var bca = new StringBuilder();
                 for (int i = 0; i < hex.Length; i++)
                 {
                     bca.Append(input[i]);

--- a/MPF.Processors/CleanRip.cs
+++ b/MPF.Processors/CleanRip.cs
@@ -173,9 +173,18 @@ namespace MPF.Processors
                 if (hex == null)
                     return null;
 
-                // Separate into blocks of 4 hex digits and then lines
-                string bca = Regex.Replace(hex, "[0-9a-fA-F]{4}", "$0 ");
-                return SplitString(bca, 36, trim: true);
+                // Separate into blocks of 4 hex digits and newlines
+                bca = new StringBuilder();
+                for (int i = 0; i < hex.Length; i++)
+                {
+                    bca.Append(input[i]);
+                    if ((i + 1) % 32 == 0)
+                        bca.AppendLine();
+                    else if ((i + 1) % 4 == 0)
+                        bca.Append(' ');
+                }
+
+                return bca.ToString();
             }
             catch
             {


### PR DESCRIPTION
Intended output:
```
0000 0000 0000 0000 0000 0000 0000 0000
0000 0000 0000 0000 0000 0000 0000 0000
0000 0000 0000 0000 0000 0000 0000 0000
0000 0000 5044 4D43 0905 8805 2000 2008
```

Adds a space after every 4 characters, except for every 32 characters where it replaces with a newline instead.