### PR TITLE
Fix bug with volume labels

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -73,6 +73,7 @@
 - Fix issue with odd quoting
 - Add DumpingParameters for DIC and Redumper
 - Better deal with volume labels
+- Fix bug with volume labels
 
 ### 3.2.4 (2024-11-24)
 

--- a/MPF.Frontend/Tools/SubmissionGenerator.cs
+++ b/MPF.Frontend/Tools/SubmissionGenerator.cs
@@ -471,6 +471,16 @@ namespace MPF.Frontend.Tools
                     labels.Remove(key);
             }
 
+            // If no labels are left, use drive label
+            if (labels == null || labels.Count == 0)
+            {
+                // Ignore common volume labels
+                if (FrontendTool.GetRedumpSystemFromVolumeLabel(driveLabel) != null)
+                    return null;
+
+                return driveLabel;
+            }
+
             // If only one unique label left, don't mention fs
 #if NET20
             string[] keyArr = new string[labels.Count];


### PR DESCRIPTION
If all labels are deleted, revert to using just the drive label, re: https://github.com/SabreTools/MPF/issues/744