### PR TITLE
Use proper base path for redumper output check

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -77,6 +77,7 @@
 - Slight formatting tweaks
 - Update BOS to 3.3.2
 - Enable handling non-SS Xbox discs
+- Use proper base path for redumper output check
 
 ### 3.2.4 (2024-11-24)
 


### PR DESCRIPTION
Fixes an issue with MPF not finding the manufacturer file during output file check
Also minor refactor of IsManufacturerEmpty routine