### PR TITLE
Print PS4/PS5 app.pkg info

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -90,6 +90,7 @@
 - (EXPERIMENTAL) Skip log line queue
 - Fully remove processing queue code
 - Introduce maximum log length
+- Print PS4/PS5 app.pkg info
 
 ### 3.2.4 (2024-11-24)
 

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -482,7 +482,8 @@ namespace MPF.Frontend.Tools
 
                     // Read the app.pkg header
                     using var fileStream = new FileStream(appPkgPath, FileMode.Open, FileAccess.Read);
-                    var appPkgHeader = SabreTools.Serialization.Deserializers.AppPkgHeader.Deserialize(fileStream);
+                    var appPkgHeaderDeserializer = new SabreTools.Serialization.Deserializers.AppPkgHeader();
+                    var appPkgHeader = appPkgHeaderDeserializer.Deserialize(fileStream);
 
                     byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
                     if (BitConverter.IsLittleEndian)
@@ -631,7 +632,8 @@ namespace MPF.Frontend.Tools
 
                     // Read the app_sc.pkg header
                     using var fileStream = new FileStream(appPkgPath, FileMode.Open, FileAccess.Read);
-                    var appPkgHeader = SabreTools.Serialization.Deserializers.AppPkgHeader.Deserialize(fileStream);
+                    var appPkgHeaderDeserializer = new SabreTools.Serialization.Deserializers.AppPkgHeader();
+                    var appPkgHeader = appPkgHeaderDeserializer.Deserialize(fileStream);
 
                     byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
                     if (BitConverter.IsLittleEndian)

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SabreTools.IO;
+using SabreTools.Serialization;
 
 namespace MPF.Frontend.Tools
 {
@@ -542,6 +543,111 @@ namespace MPF.Frontend.Tools
                 br.BaseStream.Seek(0x800, SeekOrigin.Begin);
                 byte[] jsonBytes = br.ReadBytes((int)(br.BaseStream.Length - 0x800));
                 return JsonConvert.DeserializeObject(Encoding.ASCII.GetString(jsonBytes)) as JObject;
+            }
+            catch
+            {
+                // We don't care what the error was
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Get the app.pkg info from a PlayStation 4 disc, if possible
+        /// </summary>
+        /// <param name="drive">Drive to extract information from</param>
+        /// <returns>PKG info if possible, null on error</returns>
+        public static string? GetPlayStation4PkgInfo(Drive? drive)
+        {
+            // If there's no drive path, we can't do this part
+            if (string.IsNullOrEmpty(drive?.Name))
+                return null;
+
+            // If the folder no longer exists, we can't do this part
+            if (!Directory.Exists(drive!.Name))
+                return null;
+
+            // Try parse the app.pkg (multiple if they exist)
+            try
+            {
+                string? pkgInfo = "";
+
+                string[] appDirs = Directory.GetDirectories(Path.Combine(drive.Name, "app"), "?????????", SearchOption.TopDirectoryOnly);
+
+                foreach (string dir in appDirs)
+                {
+                    string appPkgPath = Path.Combine(dir, "app.pkg");
+                    if (!File.Exists(appPkgPath))
+                        continue;
+
+                    // Read the app.pkg header
+                    using var br = new BinaryReader(File.OpenRead(appPkgPath));
+                    byte[] appPkgHeaderBuffer = br.ReadBytes(0x1000);
+                    var appPkgHeader = Deserializers.AppPkgHeader.Deserialize(appPkgHeaderBuffer);
+
+                    byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
+                    if (BitConverter.IsLittleEndian)
+                        Array.Reverse(date);
+
+                    pkgInfo = $"app.pkg ID: {appPkgHeader.ContentID}" + Environment.NewLine + $"app.pkg Date: {date[0]:X2}{date[1]:X2}-{date[2]:X2}-{date[3]:X2}";
+                }
+
+                if (pkgInfo == "")
+                    return null;
+                else
+                    return pkgInfo;
+            }
+            catch
+            {
+                // We don't care what the error was
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Get the app.pkg info from a PlayStation 5 disc, if possible
+        /// </summary>
+        /// <param name="drive">Drive to extract information from</param>
+        /// <returns>PKG info if possible, null on error</returns>
+        public static string? GetPlayStation5PkgInfo(Drive? drive)
+        {
+            // If there's no drive path, we can't do this part
+            if (string.IsNullOrEmpty(drive?.Name))
+                return null;
+
+            // If the folder no longer exists, we can't do this part
+            if (!Directory.Exists(drive!.Name))
+                return null;
+
+            // Try parse the app_sc.pkg (multiple if they exist)
+            try
+            {
+                string? pkgInfo = "";
+
+                string[] appDirs = Directory.GetDirectories(Path.Combine(drive.Name, "app"), "?????????", SearchOption.TopDirectoryOnly);
+
+                foreach (string dir in appDirs)
+                {
+                    string appPkgPath = Path.Combine(dir, "app_sc.pkg");
+                    if (!File.Exists(appPkgPath))
+                        continue;
+
+                    // Read the app_sc.pkg header
+                    using var br = new BinaryReader(File.OpenRead(appPkgPath));
+                    byte[] appPkgHeaderBuffer = br.ReadBytes(0x1000);
+                    var appPkgHeader = Deserializers.AppPkgHeader.Deserialize(appPkgHeaderBuffer);
+
+                    byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
+                    if (BitConverter.IsLittleEndian)
+                        Array.Reverse(date);
+
+                    string pkgDate = $"{date[0]:X2}{date[1]:X2}-{date[2]:X2}-{date[3]:X2}";
+                    pkgInfo = $"app_sc.pkg ID: {appPkgHeader.ContentID}" + Environment.NewLine + $"app_sc.pkg Date: {pkgDate}";
+                }
+
+                if (pkgInfo == "")
+                    return null;
+                else
+                    return pkgInfo;
             }
             catch
             {

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -485,11 +485,14 @@ namespace MPF.Frontend.Tools
                     var appPkgHeaderDeserializer = new SabreTools.Serialization.Deserializers.AppPkgHeader();
                     var appPkgHeader = appPkgHeaderDeserializer.Deserialize(fileStream);
 
-                    byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
-                    if (BitConverter.IsLittleEndian)
-                        Array.Reverse(date);
+                    if (appPkgHeader != null)
+                    {
+                        byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
+                        if (BitConverter.IsLittleEndian)
+                            Array.Reverse(date);
 
-                    pkgInfo = $"app.pkg ID: {appPkgHeader.ContentID}" + Environment.NewLine + $"app.pkg Date: {date[0]:X2}{date[1]:X2}-{date[2]:X2}-{date[3]:X2}";
+                        pkgInfo = $"app.pkg ID: {appPkgHeader.ContentID}" + Environment.NewLine + $"app.pkg Date: {date[0]:X2}{date[1]:X2}-{date[2]:X2}-{date[3]:X2}";
+                    }
                 }
 
                 if (pkgInfo == "")
@@ -635,12 +638,15 @@ namespace MPF.Frontend.Tools
                     var appPkgHeaderDeserializer = new SabreTools.Serialization.Deserializers.AppPkgHeader();
                     var appPkgHeader = appPkgHeaderDeserializer.Deserialize(fileStream);
 
-                    byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
-                    if (BitConverter.IsLittleEndian)
-                        Array.Reverse(date);
+                    if (appPkgHeader != null)
+                    {
+                        byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
+                        if (BitConverter.IsLittleEndian)
+                            Array.Reverse(date);
 
-                    string pkgDate = $"{date[0]:X2}{date[1]:X2}-{date[2]:X2}-{date[3]:X2}";
-                    pkgInfo = $"app_sc.pkg ID: {appPkgHeader.ContentID}" + Environment.NewLine + $"app_sc.pkg Date: {pkgDate}";
+                        string pkgDate = $"{date[0]:X2}{date[1]:X2}-{date[2]:X2}-{date[3]:X2}";
+                        pkgInfo = $"app_sc.pkg ID: {appPkgHeader.ContentID}" + Environment.NewLine + $"app_sc.pkg Date: {pkgDate}";
+                    }
                 }
 
                 if (pkgInfo == "")

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -481,9 +481,8 @@ namespace MPF.Frontend.Tools
                         continue;
 
                     // Read the app.pkg header
-                    using var br = new BinaryReader(File.OpenRead(appPkgPath));
-                    byte[] appPkgHeaderBuffer = br.ReadBytes(0x1000);
-                    var appPkgHeader = SabreTools.Serialization.Deserializers.AppPkgHeader.Deserialize(appPkgHeaderBuffer);
+                    using var fileStream = new FileStream(appPkgPath, FileMode.Open, FileAccess.Read);
+                    var appPkgHeader = SabreTools.Serialization.Deserializers.AppPkgHeader.Deserialize(fileStream);
 
                     byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
                     if (BitConverter.IsLittleEndian)
@@ -631,9 +630,8 @@ namespace MPF.Frontend.Tools
                         continue;
 
                     // Read the app_sc.pkg header
-                    using var br = new BinaryReader(File.OpenRead(appPkgPath));
-                    byte[] appPkgHeaderBuffer = br.ReadBytes(0x1000);
-                    var appPkgHeader = SabreTools.Serialization.Deserializers.AppPkgHeader.Deserialize(appPkgHeaderBuffer);
+                    using var fileStream = new FileStream(appPkgPath, FileMode.Open, FileAccess.Read);
+                    var appPkgHeader = SabreTools.Serialization.Deserializers.AppPkgHeader.Deserialize(fileStream);
 
                     byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
                     if (BitConverter.IsLittleEndian)

--- a/MPF.Frontend/Tools/SubmissionGenerator.cs
+++ b/MPF.Frontend/Tools/SubmissionGenerator.cs
@@ -921,11 +921,13 @@ namespace MPF.Frontend.Tools
                 case RedumpSystem.SonyPlayStation4:
                     SetCommentFieldIfNotExists(info, SiteCode.InternalSerialName, drive, PhysicalTool.GetPlayStation4Serial);
                     SetVersionIfNotExists(info, drive, PhysicalTool.GetPlayStation4Version);
+                    SetContentFieldIfNotExists(info, SiteCode.Games, drive, PhysicalTool.GetPlayStation4PkgInfo);
                     break;
 
                 case RedumpSystem.SonyPlayStation5:
                     SetCommentFieldIfNotExists(info, SiteCode.InternalSerialName, drive, PhysicalTool.GetPlayStation5Serial);
                     SetVersionIfNotExists(info, drive, PhysicalTool.GetPlayStation5Version);
+                    SetContentFieldIfNotExists(info, SiteCode.Games, drive, PhysicalTool.GetPlayStation5PkgInfo);
                     break;
 
                 case RedumpSystem.TomyKissSite:


### PR DESCRIPTION
For PS4 and PS5 discs, puts app.pkg Content ID and pkg Date into the Contents field, with SiteCode.Games 

PS4 Example:
```
<b>Games</b>:
app.pkg ID: EP4365-CUSA17823_00-SPACE00STARTOPIA
app.pkg Date: 2019-08-01
```

PS5 Example:
```
<b>Games</b>:
app_sc.pkg ID: UP2125-PPSA03355_00-3466019145463410
app_sc.pkg Date: 2020-07-22
```

Tested.
Solves #771