### PR TITLE
Improve system detection

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -124,7 +124,7 @@
 - Check for partial dumps
 - Slightly reduce nesting of file pre-dump checks
 - Slightly increase nesting of file pre-dump checks
-- Improve Sega system detection
+- Improve system detection
 
 ### 3.2.4 (2024-11-24)
 

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -124,6 +124,7 @@
 - Check for partial dumps
 - Slightly reduce nesting of file pre-dump checks
 - Slightly increase nesting of file pre-dump checks
+- Improve Sega system detection
 
 ### 3.2.4 (2024-11-24)
 

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -752,7 +752,7 @@ namespace MPF.Frontend.Tools
             if (drive == null)
                 return null;
 
-            byte[]? firstSector = GetFirstBytes(drive, 0x10);
+            var firstSector = GetFirstBytes(drive, 0x10);
             if (firstSector == null || firstSector.Length < 0x10)
                 return null;
             
@@ -786,7 +786,7 @@ namespace MPF.Frontend.Tools
             if (drive == null)
                 return null;
 
-            byte[]? firstSector = GetFirstBytes(drive, 0xC0);
+            var firstSector = GetFirstBytes(drive, 0xC0);
             if (firstSector == null || firstSector.Length < 0xC0)
                 return null;
             

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -746,7 +746,7 @@ namespace MPF.Frontend.Tools
         /// Detect the Sega system based on the CD ROM header
         /// </summary>
         /// <param name="drive">Drive to detect system from</param>
-        /// <returns>Detected RedumpSystem if detected, null on error</returns>
+        /// <returns>Detected RedumpSystem if detected, null otherwise</returns>
         public static RedumpSystem? DetectSegaSystem(Drive? drive)
         {
             if (drive == null)
@@ -768,6 +768,32 @@ namespace MPF.Frontend.Tools
                 return RedumpSystem.SegaMegaCDSegaCD;
             else if (systemType.Equals("SEGA GENESIS    ", StringComparison.Ordinal))
                 return RedumpSystem.SegaMegaCDSegaCD;
+
+            return null;
+        }
+
+        #endregion
+    
+        #region Other
+
+        /// <summary>
+        /// Detect a 3DO disc based on the CD ROM header
+        /// </summary>
+        /// <param name="drive">Drive to detect 3DO disc from</param>
+        /// <returns>RedumpSystem.Panasonic3DOInteractiveMultiplayer if detected, null otherwise</returns>
+        public static RedumpSystem? Detect3DOSystem(Drive? drive)
+        {
+            if (drive == null)
+                return null;
+
+            byte[]? firstSector = GetFirstBytes(drive, 0x90);
+            if (firstSector == null || firstSector.Length < 0x90)
+                return null;
+            
+            string systemType = Encoding.ASCII.GetString(firstSector, 0x84, 0xC);
+
+            if (systemType.Equals("duckiamaduck", StringComparison.Ordinal))
+                return RedumpSystem.Panasonic3DOInteractiveMultiplayer;
 
             return null;
         }

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -84,7 +84,7 @@ namespace MPF.Frontend.Tools
                         return null;
                 }
             }
-            catch (Exception ex)
+            catch
             {
                 // We don't care what the error is
                 return null;

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -72,7 +72,7 @@ namespace MPF.Frontend.Tools
                 numBytes = 2048;
             
             string drivePath = $"\\\\.\\{drive.Letter}:";
-            byte[]? firstSector = new byte[numBytes];
+            var firstSector = new byte[numBytes];
             try
             {
                 // Open the drive as a raw device
@@ -752,7 +752,7 @@ namespace MPF.Frontend.Tools
             if (drive == null)
                 return null;
 
-            var firstSector = GetFirstBytes(drive, 0x10);
+            byte[]? firstSector = GetFirstBytes(drive, 0x10);
             if (firstSector == null || firstSector.Length < 0x10)
                 return null;
             
@@ -786,7 +786,7 @@ namespace MPF.Frontend.Tools
             if (drive == null)
                 return null;
 
-            var firstSector = GetFirstBytes(drive, 0xC0);
+            byte[]? firstSector = GetFirstBytes(drive, 0xC0);
             if (firstSector == null || firstSector.Length < 0xC0)
                 return null;
             

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -786,13 +786,13 @@ namespace MPF.Frontend.Tools
             if (drive == null)
                 return null;
 
-            byte[]? firstSector = GetFirstBytes(drive, 0x90);
-            if (firstSector == null || firstSector.Length < 0x90)
+            byte[]? firstSector = GetFirstBytes(drive, 0xC0);
+            if (firstSector == null || firstSector.Length < 0xC0)
                 return null;
             
-            string systemType = Encoding.ASCII.GetString(firstSector, 0x84, 0xC);
+            string systemType = Encoding.ASCII.GetString(firstSector, 0xB0, 0x10);
 
-            if (systemType.Equals("duckiamaduck", StringComparison.Ordinal))
+            if (systemType.Equals("iamaduckiamaduck", StringComparison.Ordinal))
                 return RedumpSystem.Panasonic3DOInteractiveMultiplayer;
 
             return null;

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SabreTools.IO;
+using SabreTools.RedumpLib.Data;
 
 namespace MPF.Frontend.Tools
 {

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -762,6 +762,8 @@ namespace MPF.Frontend.Tools
                 return RedumpSystem.SegaSaturn;
             else if (systemType.Equals("SEGA SEGAKATANA ", StringComparison.Ordinal))
                 return RedumpSystem.SegaDreamcast;
+            else if (systemType.Equals("SEGADISCSYSTEM  ", StringComparison.Ordinal))
+                return RedumpSystem.SegaMegaCDSegaCD;
             else if (systemType.Equals("SEGA MEGA DRIVE ", StringComparison.Ordinal))
                 return RedumpSystem.SegaMegaCDSegaCD;
             else if (systemType.Equals("SEGA GENESIS    ", StringComparison.Ordinal))

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1698,6 +1698,12 @@ namespace MPF.Frontend.ViewModels
 
             #region Computers
 
+            // Amiga CD (Do this check AFTER CD32/CDTV)
+            if (File.Exists(Path.Combine(drive.Name, "Disk.info")))
+            {
+                return RedumpSystem.CommodoreAmigaCD;
+            }
+
             // Fujitsu FM Towns
             try
             {
@@ -1709,8 +1715,6 @@ namespace MPF.Frontend.ViewModels
                 }
             }
             catch { }
-
-            #endregion
 
             // Sharp X68000
             if (File.Exists(Path.Combine(drive.Name, "COMMAND.X")))

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1666,8 +1666,8 @@ namespace MPF.Frontend.ViewModels
             {
                 if (File.Exists(Path.Combine(drive.Name, "ABS.TXT"))
                     || File.Exists(Path.Combine(drive.Name, "BIB.TXT"))
-                    || File.Exists(Path.Combine(drive.Name, "IPL.TXT"))
-                    || File.Exists(Path.Combine(drive.Name, "BIB.TXT")))
+                    || File.Exists(Path.Combine(drive.Name, "CPY.TXT"))
+                    || File.Exists(Path.Combine(drive.Name, "IPL.TXT")))
                 {
                     return RedumpSystem.SNKNeoGeoCD;
                 }

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1627,10 +1627,10 @@ namespace MPF.Frontend.ViewModels
             catch { }
 
             // Sega Saturn / Sega Dreamcast / Sega Mega-CD / Sega-CD
-            RedumpSystem? detectedSegaSystem = PhysicalTool.DetectSegaSystem(drive);
-            if (detectedSegaSystem != null)
+            RedumpSystem? segaSystem = PhysicalTool.DetectSegaSystem(drive);
+            if (segaSystem != null)
             {
-                return detectedSegaSystem;
+                return segaSystem;
             }
 
             // Sega Dreamcast

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -663,8 +663,7 @@ namespace MPF.Frontend.ViewModels
                 CopyProtectScanButtonEnabled = true;
 
                 // Get the current system type
-                if (index != -1)
-                    DetermineSystemType();
+                DetermineSystemType();
 
                 // Only enable the start/stop if we don't have the default selected
                 StartStopButtonEnabled = ShouldEnableDumpingButton();
@@ -1644,6 +1643,19 @@ namespace MPF.Frontend.ViewModels
                 return RedumpSystem.SegaMegaCDSegaCD;
             }
 
+            // SNK Neo-Geo CD
+            try
+            {
+                if (File.Exists(Path.Combine(drive.Name, "ABS.TXT"))
+                    || File.Exists(Path.Combine(drive.Name, "BIB.TXT"))
+                    || File.Exists(Path.Combine(drive.Name, "IPL.TXT"))
+                    || File.Exists(Path.Combine(drive.Name, "BIB.TXT")))
+                {
+                    return RedumpSystem.SNKNeoGeoCD;
+                }
+            }
+            catch { }
+
             // Sony PlayStation and Sony PlayStation 2
             string psxExePath = Path.Combine(drive.Name, "PSX.EXE");
             string systemCnfPath = Path.Combine(drive.Name, "SYSTEM.CNF");
@@ -1697,6 +1709,16 @@ namespace MPF.Frontend.ViewModels
             if (File.Exists(Path.Combine(drive.Name, "0SYSTEM")))
             {
                 return RedumpSystem.VTechVFlashVSmilePro;
+            }
+
+            // VM Labs NUON
+#if NET20 || NET35
+            if (File.Exists(Path.Combine(Path.Combine(drive.Name, "NUON"), "nuon.run")))
+#else
+            if (File.Exists(Path.Combine(drive.Name, "NUON", "nuon.run")))
+#endif
+            {
+                return RedumpSystem.VMLabsNUON;
             }
 
             #endregion

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1573,6 +1573,12 @@ namespace MPF.Frontend.ViewModels
                 return RedumpSystem.MattelFisherPriceiXL;
             }
 
+            // Memorex - Visual Information System
+            if (File.Exists(Path.Combine(drive.Name, "CONTROL.TAT")))
+            {
+                return RedumpSystem.MemorexVisualInformationSystem;
+            }
+
             // Microsoft Xbox 360
             try
             {
@@ -1731,6 +1737,12 @@ namespace MPF.Frontend.ViewModels
 #endif
             {
                 return RedumpSystem.VMLabsNUON;
+            }
+
+            // ZAPit Games - GameWave
+            if (File.Exists(Path.Combine(drive.Name, "gamewave.diz")))
+            {
+                return RedumpSystem.ZAPiTGamesGameWaveFamilyEntertainmentSystem;
             }
 
             #endregion

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1264,9 +1264,13 @@ namespace MPF.Frontend.ViewModels
                 // If undetected system on inactive drive, and PC is the default system, check for potential Mac disc
                 if (currentSystem == null && CurrentDrive.MarkedActive == false && Options.DefaultSystem == RedumpSystem.IBMPCcompatible)
                 {
-                    // If disc is readable on inactive drive, assume it is a Mac disc
-                    if (PhysicalTool.GetFirstBytes(CurrentDrive, 1) != null)
-                        currentSystem = RedumpSystem.AppleMacintosh;
+                    try
+                    {
+                        // If disc is readable on inactive drive, assume it is a Mac disc
+                        if (PhysicalTool.GetFirstBytes(CurrentDrive, 1) != null)
+                            currentSystem = RedumpSystem.AppleMacintosh;
+                    }
+                    catch {}
                 }
 
                 // Fallback to default system only if drive is active
@@ -1478,19 +1482,23 @@ namespace MPF.Frontend.ViewModels
             // If we can't read the files in the drive, we can only perform physical checks
             if (drive.MarkedActive == false || !Directory.Exists(drive.Name))
             {
-                // Check for Panasonic 3DO - filesystem not readable on Windows
-                RedumpSystem? detected3DOSystem = PhysicalTool.Detect3DOSystem(drive);
-                if (detected3DOSystem != null)
+                try
                 {
-                    return detected3DOSystem;
-                }
+                    // Check for Panasonic 3DO - filesystem not readable on Windows
+                    RedumpSystem? detected3DOSystem = PhysicalTool.Detect3DOSystem(drive);
+                    if (detected3DOSystem != null)
+                    {
+                        return detected3DOSystem;
+                    }
 
-                // Sega Saturn / Sega Dreamcast / Sega Mega-CD / Sega-CD
-                RedumpSystem? detectedSegaSystem = PhysicalTool.DetectSegaSystem(drive);
-                if (detectedSegaSystem != null)
-                {
-                    return detectedSegaSystem;
+                    // Sega Saturn / Sega Dreamcast / Sega Mega-CD / Sega-CD
+                    RedumpSystem? detectedSegaSystem = PhysicalTool.DetectSegaSystem(drive);
+                    if (detectedSegaSystem != null)
+                    {
+                        return detectedSegaSystem;
+                    }
                 }
+                catch {}
 
                 // Otherwise, return null
                 return null;
@@ -1632,13 +1640,17 @@ namespace MPF.Frontend.ViewModels
             }
             catch { }
 
-            // Sega Saturn / Sega Dreamcast / Sega Mega-CD / Sega-CD
-            RedumpSystem? segaSystem = PhysicalTool.DetectSegaSystem(drive);
-            if (segaSystem != null)
+            try
             {
-                return segaSystem;
+                // Sega Saturn / Sega Dreamcast / Sega Mega-CD / Sega-CD
+                RedumpSystem? segaSystem = PhysicalTool.DetectSegaSystem(drive);
+                if (segaSystem != null)
+                {
+                    return segaSystem;
+                }
             }
-
+            catch {}
+            
             // Sega Dreamcast
             if (File.Exists(Path.Combine(drive.Name, "IP.BIN")))
             {

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1604,7 +1604,7 @@ namespace MPF.Frontend.ViewModels
             catch { }
 
             // Sega Saturn/Dreamcast/Mega-CD/Sega-CD
-            RedumpSystem? detectedSegaSystem = DetectSegaSystem(drive);
+            RedumpSystem? detectedSegaSystem = PhysicalTool.DetectSegaSystem(drive);
             if (detectedSegaSystem != null)
             {
                 return detectedSegaSystem;

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1465,7 +1465,7 @@ namespace MPF.Frontend.ViewModels
         /// <summary>
         /// Get the current system from drive
         /// </summary>
-        private static RedumpSystem? GetRedumpSystem(Drive? drive, bool physicalCheck)
+        private static RedumpSystem? GetRedumpSystem(Drive? drive)
         {
             // If the drive does not exist, we can't do anything
             if (drive == null || string.IsNullOrEmpty(drive.Name))

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1603,6 +1603,13 @@ namespace MPF.Frontend.ViewModels
             }
             catch { }
 
+            // Sega Saturn/Dreamcast/Mega-CD/Sega-CD
+            RedumpSystem? detectedSegaSystem = DetectSegaSystem(drive);
+            if (detectedSegaSystem != null)
+            {
+                return detectedSegaSystem;
+            }
+
             // Sega Dreamcast
             if (File.Exists(Path.Combine(drive.Name, "IP.BIN")))
             {

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1603,7 +1603,14 @@ namespace MPF.Frontend.ViewModels
             }
             catch { }
 
-            // Sega Saturn/Dreamcast/Mega-CD/Sega-CD
+            // Panasonic 3DO
+            RedumpSystem? detected3DOSystem = PhysicalTool.Detect3DOSystem(drive);
+            if (detected3DOSystem != null)
+            {
+                return detected3DOSystem;
+            }
+
+            // Sega Saturn / Sega Dreamcast / Sega Mega-CD / Sega-CD
             RedumpSystem? detectedSegaSystem = PhysicalTool.DetectSegaSystem(drive);
             if (detectedSegaSystem != null)
             {
@@ -1662,17 +1669,6 @@ namespace MPF.Frontend.ViewModels
             catch { }
 
             // Sony PlayStation 4
-            // There are more possible paths that could be checked.
-            //  There are some entries that can be found on most PS4 discs:
-            //    "/app/GAME_SERIAL/app.pkg"
-            //    "/bd/param.sfo"
-            //    "/license/rif"
-            // There are also extra files that can be found on some discs:
-            //    "/patch/GAME_SERIAL/patch.pkg" can be found in Redump entry 66816.
-            //        Originally on disc as "/patch/CUSA11302/patch.pkg".
-            //        Is used as an on-disc update for the base game app without needing to get update from the internet.
-            //    "/addcont/GAME_SERIAL/CONTENT_ID/ac.pkg" can be found in Redump entry 97619.
-            //        Originally on disc as "/addcont/CUSA00288/FFXIVEXPS400001A/ac.pkg".
 #if NET20 || NET35
             if (File.Exists(Path.Combine(Path.Combine(Path.Combine(drive.Name, "PS4"), "UPDATE"), "PS4UPDATE.PUP")))
 #else
@@ -1680,6 +1676,16 @@ namespace MPF.Frontend.ViewModels
 #endif
             {
                 return RedumpSystem.SonyPlayStation4;
+            }
+
+            // Sony PlayStation 5
+#if NET20 || NET35
+            if (File.Exists(Path.Combine(Path.Combine(Path.Combine(drive.Name, "PS5"), "UPDATE"), "PS5UPDATE.PUP")))
+#else
+            if (File.Exists(Path.Combine(drive.Name, "PS5", "UPDATE", "PS5UPDATE.PUP")))
+#endif
+            {
+                return RedumpSystem.SonyPlayStation5;
             }
 
             // V.Tech V.Flash / V.Smile Pro
@@ -1691,6 +1697,20 @@ namespace MPF.Frontend.ViewModels
             #endregion
 
             #region Computers
+
+            // Fujitsu FM Towns
+            try
+            {
+                if (File.Exists(Path.Combine(drive.Name, "TMENU.EXP"))
+                    || File.Exists(Path.Combine(drive.Name, "TBIOS.SYS"))
+                    || File.Exists(Path.Combine(drive.Name, "TBIOS.BIN")))
+                {
+                    return RedumpSystem.FujitsuFMTownsseries;
+                }
+            }
+            catch { }
+
+            #endregion
 
             // Sharp X68000
             if (File.Exists(Path.Combine(drive.Name, "COMMAND.X")))


### PR DESCRIPTION
- Reads the Sega Header to detect the system
- Better PS5 detection
- FMT detection
- Amiga CD (non-CD32/CDTV)
- 3DO detection (no false positives, but won't detect all 3DO discs)
- Neo Geo CD detection
- NUON detection
- GameWave detection
- VIS detection
- If PC is default and disc has unreadable filesystem, default to Mac instead