### PR TITLE
Add pure-getkey output names for PS3CFW

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -142,6 +142,7 @@
 - Reenable XGD1 PVD reporting
 - Improve PS4/PS5 parsing
 - Don't add special field keys with no reason
+- Add pure-getkey output names for PS3CFW
 
 ### 3.2.4 (2024-11-24)
 

--- a/MPF.Processors.Test/PS3CFWTests.cs
+++ b/MPF.Processors.Test/PS3CFWTests.cs
@@ -29,7 +29,7 @@ namespace MPF.Processors.Test
             var processor = new PS3CFW(RedumpSystem.SonyPlayStation3, MediaType.BluRay);
 
             var actual = processor.GetOutputFiles(baseDirectory, baseFilename);
-            Assert.Equal(3, actual.Count);
+            Assert.Equal(4, actual.Count);
         }
 
         [Fact]

--- a/MPF.Processors/PS3CFW.cs
+++ b/MPF.Processors/PS3CFW.cs
@@ -79,11 +79,11 @@ namespace MPF.Processors
                 case MediaType.BluRay:
                     return [
                         new($"{baseFilename}.iso", OutputFileFlags.Required),
-                        new($"{baseFilename}.getkey.log", OutputFileFlags.Required
+                        new([$"{baseFilename}.getkey.log", "getkey.log"], OutputFileFlags.Required
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,
                             "getkey_log"),
-                        new($"{baseFilename}.disc.pic", OutputFileFlags.Required
+                        new([$"{baseFilename}.disc.pic", "disc.pic"], OutputFileFlags.Required
                             | OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "disc_pic"),

--- a/MPF.Processors/PS3CFW.cs
+++ b/MPF.Processors/PS3CFW.cs
@@ -78,8 +78,8 @@ namespace MPF.Processors
             {
                 case MediaType.BluRay:
                     return [
-                        new($"{baseFilename}.iso", OutputFileFlags.Required),
-                        new($"{baseFilename}.CUE", OutputFileFlags.Zippable),
+                        new([$"{baseFilename}.iso", $"{baseFilename}.ISO"], OutputFileFlags.Required),
+                        new([$"{baseFilename}.cue", $"{baseFilename}.CUE"], OutputFileFlags.Zippable),
                         new([$"{baseFilename}.getkey.log", "getkey.log"], OutputFileFlags.Required
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,

--- a/MPF.Processors/PS3CFW.cs
+++ b/MPF.Processors/PS3CFW.cs
@@ -48,19 +48,19 @@ namespace MPF.Processors
             // Try to determine the name of the GetKey file(s)
             string? getKeyBasePath = GetCFWBasePath(basePath);
 
-            // If GenerateSubmissionInfo is run, .getkey.log existence should already be checked
-            if (!File.Exists(getKeyBasePath + ".getkey.log"))
+            // If GenerateSubmissionInfo is run, getkey.log existence should already be checked
+            if (!File.Exists(getKeyBasePath + "getkey.log"))
                 return;
 
             // Get dumping date from GetKey log date
-            info.DumpingInfo.DumpingDate = ProcessingTool.GetFileModifiedDate(getKeyBasePath + ".getkey.log")?.ToString("yyyy-MM-dd HH:mm:ss");
+            info.DumpingInfo.DumpingDate = ProcessingTool.GetFileModifiedDate(getKeyBasePath + "getkey.log")?.ToString("yyyy-MM-dd HH:mm:ss");
 
             // TODO: Put info about abnormal PIC info beyond 132 bytes in comments?
-            if (File.Exists(getKeyBasePath + ".disc.pic"))
-                info.Extras!.PIC = GetPIC(getKeyBasePath + ".disc.pic", 264);
+            if (File.Exists(getKeyBasePath + "disc.pic"))
+                info.Extras!.PIC = GetPIC(getKeyBasePath + "disc.pic", 264);
 
-            // Parse Disc Key, Disc ID, and PIC from the .getkey.log file
-            if (ProcessingTool.ParseGetKeyLog(getKeyBasePath + ".getkey.log", out string? key, out string? id, out string? pic))
+            // Parse Disc Key, Disc ID, and PIC from the getkey.log file
+            if (ProcessingTool.ParseGetKeyLog(getKeyBasePath + "getkey.log", out string? key, out string? id, out string? pic))
             {
                 if (key != null)
                     info.Extras!.DiscKey = key.ToUpperInvariant();
@@ -133,7 +133,7 @@ namespace MPF.Processors
         #region Helper Functions
 
         /// <summary>
-        /// Estimate the base filename of the .getkey.log file associated with the dump
+        /// Estimate the base filename of the getkey.log file associated with the dump
         /// </summary>
         /// <param name="iso">Path to ISO file</param>
         /// <returns>Base filename, null if not found</returns>
@@ -148,12 +148,12 @@ namespace MPF.Processors
             try
             {
                 string dir = Path.GetDirectoryName(iso) ?? ".";
-                string[] files = Directory.GetFiles(dir, "*.getkey.log");
+                string[] files = Directory.GetFiles(dir, "*getkey.log");
 
                 if (files.Length != 1)
                     return null;
 
-                return files[0].Substring(0, files[0].Length - 11);
+                return files[0].Substring(0, files[0].Length - 10);
             }
             catch
             {

--- a/MPF.Processors/PS3CFW.cs
+++ b/MPF.Processors/PS3CFW.cs
@@ -79,6 +79,7 @@ namespace MPF.Processors
                 case MediaType.BluRay:
                     return [
                         new($"{baseFilename}.iso", OutputFileFlags.Required),
+                        new($"{baseFilename}.CUE", OutputFileFlags.Zippable),
                         new([$"{baseFilename}.getkey.log", "getkey.log"], OutputFileFlags.Required
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,


### PR DESCRIPTION
Add pure getkey output names for PS3CFW (getkey.log, disc.pic)
Also, zip any CUE file generated by multiman