### PR TITLE
Minor UI and other fixes

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -145,6 +145,7 @@
 - Add pure-getkey output names for PS3CFW
 - Partially clean up PS3CFW
 - Wrap some PhysicalTool method calls
+- Minor UI and other fixes
 
 ### 3.2.4 (2024-11-24)
 

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -205,8 +205,7 @@ namespace MPF.Frontend.Tools
             }
             catch
             {
-                // We don't care what the error is
-                return null;
+                // We don't care what the error is, assume SYSTEM.CNF doesn't exist
             }
 
             // If the SYSTEM.CNF value can't be found, try PSX.EXE

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -555,7 +555,7 @@ namespace MPF.Frontend.Tools
                             Array.Reverse(date);
 
                         string pkgDate = $"{date[0]:X2}{date[1]:X2}-{date[2]:X2}-{date[3]:X2}";
-                        pkgInfo += $"{appPkgHeader.ContentID} ({pkgDate}, {appPkgHeader.VersionHash:X8})";
+                        pkgInfo += $"{appPkgHeader.ContentID} ({pkgDate})";
                     }
                 }
 
@@ -713,7 +713,7 @@ namespace MPF.Frontend.Tools
                             Array.Reverse(date);
 
                         string pkgDate = $"{date[0]:X2}{date[1]:X2}-{date[2]:X2}-{date[3]:X2}";
-                        pkgInfo += $"{appPkgHeader.ContentID} ({pkgDate}, {appPkgHeader.VersionHash:X8})";
+                        pkgInfo += $"{appPkgHeader.ContentID} ({pkgDate})";
                     }
                 }
 

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -549,14 +549,7 @@ namespace MPF.Frontend.Tools
                     var appPkgHeader = appPkgHeaderDeserializer.Deserialize(fileStream);
 
                     if (appPkgHeader != null)
-                    {
-                        byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
-                        if (BitConverter.IsLittleEndian)
-                            Array.Reverse(date);
-
-                        string pkgDate = $"{date[0]:X2}{date[1]:X2}-{date[2]:X2}-{date[3]:X2}";
-                        pkgInfo += $"{appPkgHeader.ContentID} ({pkgDate})";
-                    }
+                        pkgInfo += $"{appPkgHeader.ContentID}";
                 }
 
                 if (pkgInfo == "")
@@ -707,14 +700,7 @@ namespace MPF.Frontend.Tools
                     var appPkgHeader = appPkgHeaderDeserializer.Deserialize(fileStream);
 
                     if (appPkgHeader != null)
-                    {
-                        byte[] date = BitConverter.GetBytes(appPkgHeader.VersionDate);
-                        if (BitConverter.IsLittleEndian)
-                            Array.Reverse(date);
-
-                        string pkgDate = $"{date[0]:X2}{date[1]:X2}-{date[2]:X2}-{date[3]:X2}";
-                        pkgInfo += $"{appPkgHeader.ContentID} ({pkgDate})";
-                    }
+                        pkgInfo += $"{appPkgHeader.ContentID}";
                 }
 
                 if (pkgInfo == "")

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -2061,10 +2061,7 @@ namespace MPF.Frontend.ViewModels
             VerboseLogLn($"Supported media speeds: {string.Join(", ", [.. DriveSpeeds.ConvertAll(ds => ds.ToString())])}");
 
             // Set the selected speed
-            int speed = FrontendTool.GetDefaultSpeedForMediaType(CurrentMediaType, Options);
-
-            VerboseLogLn($"Setting drive speed to: {speed}");
-            DriveSpeed = speed;
+            DriveSpeed = FrontendTool.GetDefaultSpeedForMediaType(CurrentMediaType, Options);
         }
 
         /// <summary>

--- a/MPF.UI/External/WPFCustomMessageBox/CustomMessageBoxWindow.xaml
+++ b/MPF.UI/External/WPFCustomMessageBox/CustomMessageBoxWindow.xaml
@@ -16,7 +16,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <Grid Grid.Row="0" Margin="0,10,0,0">
+            <Grid Grid.Row="0" Margin="0,2,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="25"/>
                     <ColumnDefinition Width="115"/>

--- a/MPF.UI/External/WPFCustomMessageBox/CustomMessageBoxWindow.xaml
+++ b/MPF.UI/External/WPFCustomMessageBox/CustomMessageBoxWindow.xaml
@@ -6,73 +6,75 @@
         WindowStyle="None"
         ResizeMode="NoResize" SizeToContent="WidthAndHeight"
         Title="" MinHeight="155" MaxWidth="470" MinWidth="154"
-        BorderBrush="DarkGray" BorderThickness="2">
+        AllowsTransparency="True" Background="Transparent">
 
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+    <Border CornerRadius="8" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" BorderBrush="Gray" BorderThickness="2">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                 <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
-        <Grid Grid.Row="0" Margin="0,10,0,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="25"/>
-                <ColumnDefinition Width="115"/>
-                <ColumnDefinition/>
-                <ColumnDefinition/>
-                <ColumnDefinition/>
-                <ColumnDefinition Width="50"/>
-            </Grid.ColumnDefinitions>
+            <Grid Grid.Row="0" Margin="0,10,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="25"/>
+                    <ColumnDefinition Width="115"/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition Width="50"/>
+                </Grid.ColumnDefinitions>
 
-            <Image Grid.Column="0" Source="/Images/Icon.ico" Height="20" Width="20" Margin="1" />
-            <Label Grid.Column="1" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" MouseDown="TitleMouseDown" Content="{Binding Path=Title,RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"/>
-        </Grid>
+                <Image Grid.Column="0" Source="/Images/Icon.ico" Height="20" Width="20" Margin="1" />
+                <Label Grid.Column="1" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" MouseDown="TitleMouseDown" Content="{Binding Path=Title,RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"/>
+            </Grid>
 
-        <!-- Make the window width fit the title by embedding the title invisibly  -->
-        <TextBlock Text="{Binding Path=Title,RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
-                   Visibility="Hidden" Height="0" Margin="50 0 0 0" />
+            <!-- Make the window width fit the title by embedding the title invisibly  -->
+            <TextBlock Text="{Binding Path=Title,RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
+                       Visibility="Hidden" Height="0" Margin="50 0 0 0" />
 
-        <Grid Grid.Row="1" Background="{DynamicResource CustomMessageBox.Static.Background}" MinHeight="69">
-            <DockPanel>
-                <Image Name="Image_MessageBox" Width="32" Height="32" HorizontalAlignment="Left" DockPanel.Dock="Left" Margin="30,0,0,0" Visibility="Collapsed"/>
-                <TextBlock Name="TextBlock_Message" TextWrapping="Wrap" MaxWidth="500" Width="Auto"
-                       VerticalAlignment="Center" Margin="12,20,41,15" />
-            </DockPanel>
-        </Grid>
+            <Grid Grid.Row="1" Background="{DynamicResource CustomMessageBox.Static.Background}" MinHeight="69">
+                <DockPanel>
+                    <Image Name="Image_MessageBox" Width="32" Height="32" HorizontalAlignment="Left" DockPanel.Dock="Left" Margin="30,0,0,0" Visibility="Collapsed"/>
+                    <TextBlock Name="TextBlock_Message" TextWrapping="Wrap" MaxWidth="500" Width="Auto"
+                           VerticalAlignment="Center" Margin="12,20,41,15" />
+                </DockPanel>
+            </Grid>
         
-        <Grid Grid.Row="2" Background="{DynamicResource CustomMessageBox.Static.Background}" MinHeight="49">
-            <DockPanel Margin="5,0">
+            <Grid Grid.Row="2" Background="{DynamicResource CustomMessageBox.Static.Background}" MinHeight="49">
+                <DockPanel Margin="5,0">
                 
-                <!-- Cancel Button -->
-                <Button Name="Button_Cancel" MinWidth="88" MaxWidth="160" Height="26" Margin="5,0" HorizontalAlignment="Right" Visibility="Collapsed" IsCancel="True"
-                        DockPanel.Dock="Right" Click="Button_Cancel_Click" Style="{DynamicResource CustomButtonStyle}">
-                    <Label Name="Label_Cancel" Padding="0" Margin="10,0">_Cancel</Label>
-                </Button>
-                <!-- End Cancel Button -->
+                    <!-- Cancel Button -->
+                    <Button Name="Button_Cancel" MinWidth="88" MaxWidth="160" Height="26" Margin="5,0" HorizontalAlignment="Right" Visibility="Collapsed" IsCancel="True"
+                            DockPanel.Dock="Right" Click="Button_Cancel_Click" Style="{DynamicResource CustomButtonStyle}">
+                        <Label Name="Label_Cancel" Padding="0" Margin="10,0">_Cancel</Label>
+                    </Button>
+                    <!-- End Cancel Button -->
                 
-                <!-- No Button -->
-                <Button Name="Button_No" MinWidth="88" MaxWidth="160" Height="26" Margin="5,0" HorizontalAlignment="Right" Visibility="Collapsed"
-                        DockPanel.Dock="Right" Click="Button_No_Click" Style="{DynamicResource CustomButtonStyle}">
-                    <Label Name="Label_No" Padding="0" Margin="10,0">_No</Label>
-                </Button>
-                <!-- End No Button -->
+                    <!-- No Button -->
+                    <Button Name="Button_No" MinWidth="88" MaxWidth="160" Height="26" Margin="5,0" HorizontalAlignment="Right" Visibility="Collapsed"
+                            DockPanel.Dock="Right" Click="Button_No_Click" Style="{DynamicResource CustomButtonStyle}">
+                        <Label Name="Label_No" Padding="0" Margin="10,0">_No</Label>
+                    </Button>
+                    <!-- End No Button -->
                 
-                <!-- Yes Button -->
-                <Button Name="Button_Yes" MinWidth="88" MaxWidth="160" Height="26" Margin="35,0,5,0" HorizontalAlignment="Right" Visibility="Collapsed"
-                        DockPanel.Dock="Right" Click="Button_Yes_Click" Style="{DynamicResource CustomButtonStyle}">
-                    <Label Name="Label_Yes" Padding="0" Margin="10,0">_Yes</Label>
-                </Button>
-                <!-- End Yes Button -->
+                    <!-- Yes Button -->
+                    <Button Name="Button_Yes" MinWidth="88" MaxWidth="160" Height="26" Margin="35,0,5,0" HorizontalAlignment="Right" Visibility="Collapsed"
+                            DockPanel.Dock="Right" Click="Button_Yes_Click" Style="{DynamicResource CustomButtonStyle}">
+                        <Label Name="Label_Yes" Padding="0" Margin="10,0">_Yes</Label>
+                    </Button>
+                    <!-- End Yes Button -->
                 
-                <!-- OK Button -->
-                <Button Name="Button_OK" MinWidth="88" MaxWidth="160" Margin="35,0,5,0" HorizontalAlignment="Right" Height="26"
-                        Click="Button_OK_Click" Style="{DynamicResource CustomButtonStyle}">
-                    <Label Name="Label_Ok" Padding="0" Margin="10,0">_OK</Label>
-                </Button>
-                <!-- End OK Button -->
+                    <!-- OK Button -->
+                    <Button Name="Button_OK" MinWidth="88" MaxWidth="160" Margin="35,0,5,0" HorizontalAlignment="Right" Height="26"
+                            Click="Button_OK_Click" Style="{DynamicResource CustomButtonStyle}">
+                        <Label Name="Label_Ok" Padding="0" Margin="10,0">_OK</Label>
+                    </Button>
+                    <!-- End OK Button -->
                 
-            </DockPanel>
+                </DockPanel>
+            </Grid>
         </Grid>
-    </Grid>
+    </Border>
 </Window>

--- a/MPF.UI/External/WPFCustomMessageBox/CustomMessageBoxWindow.xaml
+++ b/MPF.UI/External/WPFCustomMessageBox/CustomMessageBoxWindow.xaml
@@ -26,7 +26,7 @@
                     <ColumnDefinition Width="50"/>
                 </Grid.ColumnDefinitions>
 
-                <Image Grid.Column="0" Source="/Images/Icon.ico" Height="20" Width="20" Margin="1" />
+                <Image Grid.Column="0" Source="/Images/Icon.ico" Height="20" Width="20" Margin="1" MouseDown="TitleMouseDown" />
                 <Label Grid.Column="1" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" MouseDown="TitleMouseDown" Content="{Binding Path=Title,RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"/>
             </Grid>
 

--- a/MPF.UI/UserControls/UserInput.xaml
+++ b/MPF.UI/UserControls/UserInput.xaml
@@ -7,7 +7,7 @@
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="0.75*" />
-            <ColumnDefinition Width="1.25*" />
+            <ColumnDefinition Width="1.50*" />
         </Grid.ColumnDefinitions>
 
         <Label Grid.Row="0" Grid.Column="0"

--- a/MPF.UI/Windows/DiscInformationWindow.xaml
+++ b/MPF.UI/Windows/DiscInformationWindow.xaml
@@ -18,7 +18,7 @@
 
     <Border CornerRadius="8" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" BorderBrush="Gray" BorderThickness="2">
         <StackPanel Orientation="Vertical" MaxHeight="650">
-            <Grid Margin="0,10,0,0">
+            <Grid Margin="0,2,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="25"/>
                     <ColumnDefinition Width="115"/>

--- a/MPF.UI/Windows/DiscInformationWindow.xaml
+++ b/MPF.UI/Windows/DiscInformationWindow.xaml
@@ -8,7 +8,7 @@
                         xmlns:redump="clr-namespace:SabreTools.RedumpLib.Data;assembly=SabreTools.RedumpLib"
                         xmlns:coreWindows="clr-namespace:MPF.UI.Windows"
                         mc:Ignorable="d"
-                        Title="Disc Information" Width="515" WindowStyle="None"
+                        Title="Disc Information" Width="600" WindowStyle="None"
                         WindowStartupLocation="CenterOwner" ResizeMode="CanMinimize" SizeToContent="Height"
                         AllowsTransparency="True" Background="Transparent">
 
@@ -17,7 +17,7 @@
     </Window.Resources>
 
     <Border CornerRadius="8" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" BorderBrush="Gray" BorderThickness="2">
-        <StackPanel Orientation="Vertical" Width="500" MaxHeight="650">
+        <StackPanel Orientation="Vertical" MaxHeight="650">
             <Grid Margin="0,10,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="25"/>

--- a/MPF.UI/Windows/DiscInformationWindow.xaml
+++ b/MPF.UI/Windows/DiscInformationWindow.xaml
@@ -7,9 +7,9 @@
                         xmlns:core="clr-namespace:MPF.UI"
                         xmlns:redump="clr-namespace:SabreTools.RedumpLib.Data;assembly=SabreTools.RedumpLib"
                         xmlns:coreWindows="clr-namespace:MPF.UI.Windows"
-                        mc:Ignorable="d" MinWidth="515" Width="550" MaxWidth="1100" MaxHeight="650"
-                        Title="Disc Information" WindowStyle="None"
-                        WindowStartupLocation="CenterOwner" ResizeMode="CanResize" SizeToContent="Height"
+                        mc:Ignorable="d"
+                        Title="Disc Information" Width="600" WindowStyle="None"
+                        WindowStartupLocation="CenterOwner" ResizeMode="CanMinimize" SizeToContent="Height"
                         AllowsTransparency="True" Background="Transparent">
 
     <Window.Resources>

--- a/MPF.UI/Windows/DiscInformationWindow.xaml
+++ b/MPF.UI/Windows/DiscInformationWindow.xaml
@@ -7,9 +7,9 @@
                         xmlns:core="clr-namespace:MPF.UI"
                         xmlns:redump="clr-namespace:SabreTools.RedumpLib.Data;assembly=SabreTools.RedumpLib"
                         xmlns:coreWindows="clr-namespace:MPF.UI.Windows"
-                        mc:Ignorable="d"
-                        Title="Disc Information" Width="600" WindowStyle="None"
-                        WindowStartupLocation="CenterOwner" ResizeMode="CanMinimize" SizeToContent="Height"
+                        mc:Ignorable="d" MinWidth="515" Width="550" MaxWidth="1100" MaxHeight="650"
+                        Title="Disc Information" WindowStyle="None"
+                        WindowStartupLocation="CenterOwner" ResizeMode="CanResize" SizeToContent="Height"
                         AllowsTransparency="True" Background="Transparent">
 
     <Window.Resources>

--- a/MPF.UI/Windows/DiscInformationWindow.xaml
+++ b/MPF.UI/Windows/DiscInformationWindow.xaml
@@ -21,7 +21,7 @@
             <Grid Margin="0,2,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="25"/>
-                    <ColumnDefinition Width="100"/>
+                    <ColumnDefinition Width="115"/>
                     <ColumnDefinition/>
                     <ColumnDefinition/>
                     <ColumnDefinition/>
@@ -496,6 +496,13 @@
 
             <!-- Accept / Cancel -->
             <GroupBox Margin="5,5,5,5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <GroupBox.Template>
+                    <ControlTemplate TargetType="GroupBox">
+                        <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="5">
+                            <ContentPresenter Content="{TemplateBinding Content}" Margin="{TemplateBinding Padding}" />
+                        </Border>
+                    </ControlTemplate>
+                </GroupBox.Template>
                 <UniformGrid Columns="3" Margin="5,5,5,5" Height="28">
                     <Button Name="AcceptButton" Height="25" Width="80" Content="Accept"
                             Style="{DynamicResource CustomButtonStyle}" />

--- a/MPF.UI/Windows/DiscInformationWindow.xaml
+++ b/MPF.UI/Windows/DiscInformationWindow.xaml
@@ -21,7 +21,7 @@
             <Grid Margin="0,2,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="25"/>
-                    <ColumnDefinition Width="115"/>
+                    <ColumnDefinition Width="100"/>
                     <ColumnDefinition/>
                     <ColumnDefinition/>
                     <ColumnDefinition/>

--- a/MPF.UI/Windows/DiscInformationWindow.xaml
+++ b/MPF.UI/Windows/DiscInformationWindow.xaml
@@ -91,7 +91,7 @@
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="0.75*" />
-                                            <ColumnDefinition Width="1.25*" />
+                                            <ColumnDefinition Width="1.50*" />
                                         </Grid.ColumnDefinitions>
 
                                         <Label x:Name="CategoryLabel" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="Category" />
@@ -103,7 +103,7 @@
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="0.75*" />
-                                            <ColumnDefinition Width="1.25*" />
+                                            <ColumnDefinition Width="1.50*" />
                                         </Grid.ColumnDefinitions>
 
                                         <Label x:Name="RegionLabel" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="Region" />
@@ -115,7 +115,7 @@
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="0.75*" />
-                                            <ColumnDefinition Width="1.25*" />
+                                            <ColumnDefinition Width="1.50*" />
                                         </Grid.ColumnDefinitions>
 
                                         <Label x:Name="LanguagesLabel" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="Languages" />
@@ -133,7 +133,7 @@
                                     <Grid x:Name="LanguageSelectionGrid" Visibility="Collapsed">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="0.75*" />
-                                            <ColumnDefinition Width="1.25*" />
+                                            <ColumnDefinition Width="1.50*" />
                                         </Grid.ColumnDefinitions>
 
                                         <Label x:Name="LanguageSelectionLabel" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="Language Selection Via" />
@@ -187,7 +187,7 @@
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="0.75*" />
-                                            <ColumnDefinition Width="1.25*" />
+                                            <ColumnDefinition Width="1.50*" />
                                         </Grid.ColumnDefinitions>
 
                                         <Label/>
@@ -199,7 +199,7 @@
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="0.75*" />
-                                            <ColumnDefinition Width="1.25*" />
+                                            <ColumnDefinition Width="1.50*" />
                                         </Grid.ColumnDefinitions>
 
                                         <Label/>

--- a/MPF.UI/Windows/OptionsWindow.xaml
+++ b/MPF.UI/Windows/OptionsWindow.xaml
@@ -20,7 +20,7 @@
 
     <Border CornerRadius="8" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" BorderBrush="Gray" BorderThickness="2">
         <StackPanel Orientation="Vertical">
-            <Grid Margin="0,10,0,0">
+            <Grid Margin="0,2,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="25"/>
                     <ColumnDefinition Width="115"/>

--- a/MPF.UI/Windows/RingCodeGuideWindow.xaml
+++ b/MPF.UI/Windows/RingCodeGuideWindow.xaml
@@ -12,7 +12,7 @@
 
     <Border CornerRadius="8" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" BorderBrush="Gray" BorderThickness="1">
         <StackPanel Orientation="Vertical">
-            <Grid Margin="0,10,0,0">
+            <Grid Margin="0,2,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="25"/>
                     <ColumnDefinition Width="115"/>


### PR DESCRIPTION
- Increase width of Disc Information Window
- Change ratio of UserInput fields (3:5 to 3:6)
- Don't log drive speed change when scan for discs is pressed
- Add rounded corners to custom message box
- Standardize top margin of windows
- Better deal with case when SYSTEM.CNF doesn't exist in PSX discs
- Don't print VersionHash field for PS4/PS5 app.pkg data