### PR TITLE
Add newlines to pkg info printing

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -50,6 +50,7 @@
 - Explicitly unset Redumper speed, if needed
 - Simplify WriteOutputData path handling
 - Serialize JSON a slightly different way
+- Add newlines to pkg info printing
 
 ### 3.3.0 (2025-01-03)
 

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -700,7 +700,7 @@ namespace MPF.Frontend.Tools
                     var appPkgHeader = appPkgHeaderDeserializer.Deserialize(fileStream);
 
                     if (appPkgHeader != null)
-                        pkgInfo += $"{appPkgHeader.ContentID}";
+                        pkgInfo += $"{appPkgHeader.ContentID}" + Environment.NewLine;
                 }
 
                 if (pkgInfo == "")

--- a/MPF.Frontend/Tools/PhysicalTool.cs
+++ b/MPF.Frontend/Tools/PhysicalTool.cs
@@ -549,7 +549,7 @@ namespace MPF.Frontend.Tools
                     var appPkgHeader = appPkgHeaderDeserializer.Deserialize(fileStream);
 
                     if (appPkgHeader != null)
-                        pkgInfo += $"{appPkgHeader.ContentID}";
+                        pkgInfo += $"{appPkgHeader.ContentID}" + Environment.NewLine;
                 }
 
                 if (pkgInfo == "")


### PR DESCRIPTION
Fixes two pkgs printing on the same line
http://forum.redump.org/post/126658/