### PR TITLE
Relax PS3CFW output filename requirements

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -53,6 +53,7 @@
 - Add newlines to pkg info printing
 - Better audio-only check
 - Minor cleanup from last commit
+- Relax PS3CFW output filename requirements
 
 ### 3.3.0 (2025-01-03)
 

--- a/MPF.Processors/PS3CFW.cs
+++ b/MPF.Processors/PS3CFW.cs
@@ -80,11 +80,8 @@ namespace MPF.Processors
             else
             {
                 string[] discPicFiles = Directory.GetFiles(baseDir, "*.disc.pic");
-                string discPicPath = string.Empty;
                 if (discPicFiles.Length > 0)
-                    discPicPath = discPicFiles[0];
-                if (!string.IsNullOrEmpty(discPicPath))
-                    info.Extras!.PIC = GetPIC(discPicPath, 264);
+                    info.Extras!.PIC = GetPIC(discPicFiles[0], 264);
             }
 
             // Parse Disc Key, Disc ID, and PIC from the getkey.log file

--- a/MPF.Processors/PS3CFW.cs
+++ b/MPF.Processors/PS3CFW.cs
@@ -80,7 +80,7 @@ namespace MPF.Processors
             else
             {
                 string[] discPicFiles = Directory.GetFiles(baseDir, "*.disc.pic");
-                string? discPicPath;
+                string discPicPath = string.Empty;
                 if (discPicFiles.Length > 0)
                     discPicPath = discPicFiles[0];
                 if (!string.IsNullOrEmpty(discPicPath))

--- a/MPF.Processors/PS3CFW.cs
+++ b/MPF.Processors/PS3CFW.cs
@@ -61,6 +61,8 @@ namespace MPF.Processors
                 getKeyPath = $"{basePath}.getkey.log";
             else if (File.Exists(Path.Combine(baseDir, "getkey.log")))
                 getKeyPath = Path.Combine(baseDir, "getkey.log");
+            else
+                getKeyPath = Directory.EnumerateFiles(baseDir, "*.getkey.log").FirstOrDefault();
 
             // Get dumping date from GetKey log date
             if (!string.IsNullOrEmpty(getKeyPath))
@@ -71,6 +73,12 @@ namespace MPF.Processors
                 info.Extras!.PIC = GetPIC($"{basePath}.disc.pic", 264);
             else if (File.Exists(Path.Combine(baseDir, "disc.pic")))
                 info.Extras!.PIC = GetPIC(Path.Combine(baseDir, "disc.pic"), 264);
+            else
+            {
+                string? discPicPath = Directory.EnumerateFiles(baseDir, "*.disc.pic").FirstOrDefault();
+                if (!string.IsNullOrEmpty)
+                    info.Extras!.PIC = GetPIC(discPicPath, 264);
+            }
 
             // Parse Disc Key, Disc ID, and PIC from the getkey.log file
             if (ProcessingTool.ParseGetKeyLog(getKeyPath, out string? key, out string? id, out string? pic))
@@ -96,11 +104,11 @@ namespace MPF.Processors
                     return [
                         new([$"{outputFilename}.iso", $"{outputFilename}.ISO"], OutputFileFlags.Required),
                         new([$"{outputFilename}.cue", $"{outputFilename}.CUE"], OutputFileFlags.Zippable),
-                        new([$"{outputFilename}.getkey.log", "getkey.log"], OutputFileFlags.Required
+                        new RegexOutputFile([$"*getkey.log"], OutputFileFlags.Required
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,
                             "getkey_log"),
-                        new([$"{outputFilename}.disc.pic", "disc.pic"], OutputFileFlags.Required
+                        new RegexOutputFile([$"*.disc.pic"], OutputFileFlags.Required
                             | OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "disc_pic"),

--- a/MPF.Processors/PS3CFW.cs
+++ b/MPF.Processors/PS3CFW.cs
@@ -104,11 +104,11 @@ namespace MPF.Processors
                     return [
                         new([$"{outputFilename}.iso", $"{outputFilename}.ISO"], OutputFileFlags.Required),
                         new([$"{outputFilename}.cue", $"{outputFilename}.CUE"], OutputFileFlags.Zippable),
-                        new RegexOutputFile([$"*getkey.log"], OutputFileFlags.Required
+                        new RegexOutputFile($"getkey\.log$", OutputFileFlags.Required
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,
                             "getkey_log"),
-                        new RegexOutputFile([$"*.disc.pic"], OutputFileFlags.Required
+                        new RegexOutputFile($"disc\.pic$", OutputFileFlags.Required
                             | OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "disc_pic"),

--- a/MPF.Processors/PS3CFW.cs
+++ b/MPF.Processors/PS3CFW.cs
@@ -104,11 +104,11 @@ namespace MPF.Processors
                     return [
                         new([$"{outputFilename}.iso", $"{outputFilename}.ISO"], OutputFileFlags.Required),
                         new([$"{outputFilename}.cue", $"{outputFilename}.CUE"], OutputFileFlags.Zippable),
-                        new RegexOutputFile($"getkey\.log$", OutputFileFlags.Required
+                        new RegexOutputFile($"getkey\\.log$", OutputFileFlags.Required
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,
                             "getkey_log"),
-                        new RegexOutputFile($"disc\.pic$", OutputFileFlags.Required
+                        new RegexOutputFile($"disc\\.pic$", OutputFileFlags.Required
                             | OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "disc_pic"),

--- a/MPF.Processors/PS3CFW.cs
+++ b/MPF.Processors/PS3CFW.cs
@@ -62,7 +62,11 @@ namespace MPF.Processors
             else if (File.Exists(Path.Combine(baseDir, "getkey.log")))
                 getKeyPath = Path.Combine(baseDir, "getkey.log");
             else
-                getKeyPath = Directory.GetFiles(baseDir, "*.getkey.log")[0];
+            {
+                string[] getKeyFiles = Directory.GetFiles(baseDir, "*.getkey.log");
+                if (getKeyFiles.Length > 0)
+                    getKeyPath = getKeyFiles[0];
+            }
 
             // Get dumping date from GetKey log date
             if (!string.IsNullOrEmpty(getKeyPath))
@@ -75,7 +79,10 @@ namespace MPF.Processors
                 info.Extras!.PIC = GetPIC(Path.Combine(baseDir, "disc.pic"), 264);
             else
             {
-                string? discPicPath = Directory.GetFiles(baseDir, "*.disc.pic")[0];
+                string[] discPicFiles = Directory.GetFiles(baseDir, "*.disc.pic");
+                string? discPicPath;
+                if (discPicFiles.Length > 0)
+                    discPicPath = discPicFiles[0];
                 if (!string.IsNullOrEmpty(discPicPath))
                     info.Extras!.PIC = GetPIC(discPicPath, 264);
             }

--- a/MPF.Processors/PS3CFW.cs
+++ b/MPF.Processors/PS3CFW.cs
@@ -62,7 +62,7 @@ namespace MPF.Processors
             else if (File.Exists(Path.Combine(baseDir, "getkey.log")))
                 getKeyPath = Path.Combine(baseDir, "getkey.log");
             else
-                getKeyPath = Directory.EnumerateFiles(baseDir, "*.getkey.log").FirstOrDefault();
+                getKeyPath = Directory.GetFiles(baseDir, "*.getkey.log")[0];
 
             // Get dumping date from GetKey log date
             if (!string.IsNullOrEmpty(getKeyPath))
@@ -75,8 +75,8 @@ namespace MPF.Processors
                 info.Extras!.PIC = GetPIC(Path.Combine(baseDir, "disc.pic"), 264);
             else
             {
-                string? discPicPath = Directory.EnumerateFiles(baseDir, "*.disc.pic").FirstOrDefault();
-                if (!string.IsNullOrEmpty)
+                string? discPicPath = Directory.GetFiles(baseDir, "*.disc.pic")[0];
+                if (!string.IsNullOrEmpty(discPicPath))
                     info.Extras!.PIC = GetPIC(discPicPath, 264);
             }
 

--- a/MPF.Processors/XboxBackupCreator.cs
+++ b/MPF.Processors/XboxBackupCreator.cs
@@ -165,7 +165,7 @@ namespace MPF.Processors
                             | OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "dmi"),
-                        new RegexOutputFile("[lL]og\.txt", OutputFileFlags.Required
+                        new RegexOutputFile("[lL]og\\.txt", OutputFileFlags.Required
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,
                             "log"),

--- a/MPF.Processors/XboxBackupCreator.cs
+++ b/MPF.Processors/XboxBackupCreator.cs
@@ -165,7 +165,7 @@ namespace MPF.Processors
                             | OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "dmi"),
-                        new RegexOutputFile("[lL]og.txt", OutputFileFlags.Required
+                        new RegexOutputFile("[lL]og\.txt", OutputFileFlags.Required
                             | OutputFileFlags.Artifact
                             | OutputFileFlags.Zippable,
                             "log"),


### PR DESCRIPTION
This fixes a design error where PS3CFW expects output files with consistent basename, while ManaGunZ has filestamps in the default output name (unique per file).

I also added a literal period to the XBC log.txt check (is this needed?)