### PR TITLE
Update redumper to build 610

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -81,6 +81,7 @@
 - Reset Redump errors when an INFO block is found
 - Handle error count resets in Redumper
 - Remove unnecessary conditional
+- Update redumper to build 610
 
 ### 3.3.0 (2025-01-03)
 

--- a/publish-nix.sh
+++ b/publish-nix.sh
@@ -100,12 +100,12 @@ function download_programs() {
 
     # Redumper
     DL_MAP["Redumper_linux-arm64"]=""
-    DL_MAP["Redumper_linux-x64"]="https://github.com/superg/redumper/releases/download/build_597/redumper-2025.05.30_build597-Linux64.zip"
-    DL_MAP["Redumper_osx-arm64"]="https://github.com/superg/redumper/releases/download/build_597/redumper-2025.05.30_build597-Darwin64.zip"
-    DL_MAP["Redumper_osx-x64"]="https://github.com/superg/redumper/releases/download/build_597/redumper-2025.05.30_build597-Darwin64.zip"
+    DL_MAP["Redumper_linux-x64"]="https://github.com/superg/redumper/releases/download/build_610/redumper-2025.06.12_build610-Linux64.zip"
+    DL_MAP["Redumper_osx-arm64"]="https://github.com/superg/redumper/releases/download/build_610/redumper-2025.06.12_build610-Darwin64.zip"
+    DL_MAP["Redumper_osx-x64"]="https://github.com/superg/redumper/releases/download/build_610/redumper-2025.06.12_build610-Darwin64.zip"
     DL_MAP["Redumper_win-arm64"]=""
-    DL_MAP["Redumper_win-x86"]="https://github.com/superg/redumper/releases/download/build_597/redumper-2025.05.30_build597-Windows32.zip"
-    DL_MAP["Redumper_win-x64"]="https://github.com/superg/redumper/releases/download/build_597/redumper-2025.05.30_build597-Windows64.zip"
+    DL_MAP["Redumper_win-x86"]="https://github.com/superg/redumper/releases/download/build_610/redumper-2025.06.12_build610-Windows32.zip"
+    DL_MAP["Redumper_win-x64"]="https://github.com/superg/redumper/releases/download/build_610/redumper-2025.06.12_build610-Windows64.zip"
 
     # Download and extract files
     echo "===== Downloading Required Programs ====="

--- a/publish-win.ps1
+++ b/publish-win.ps1
@@ -89,12 +89,12 @@ function Download-Programs {
 
         # Redumper
         "Redumper_linux-arm64" = ""
-        "Redumper_linux-x64"   = "https://github.com/superg/redumper/releases/download/build_597/redumper-2025.05.30_build597-Linux64.zip"
-        "Redumper_osx-arm64"   = "https://github.com/superg/redumper/releases/download/build_597/redumper-2025.05.30_build597-Darwin64.zip"
-        "Redumper_osx-x64"     = "https://github.com/superg/redumper/releases/download/build_597/redumper-2025.05.30_build597-Darwin64.zip"
+        "Redumper_linux-x64"   = "https://github.com/superg/redumper/releases/download/build_610/redumper-2025.06.12_build610-Linux64.zip"
+        "Redumper_osx-arm64"   = "https://github.com/superg/redumper/releases/download/build_610/redumper-2025.06.12_build610-Darwin64.zip"
+        "Redumper_osx-x64"     = "https://github.com/superg/redumper/releases/download/build_610/redumper-2025.06.12_build610-Darwin64.zip"
         "Redumper_win-arm64"   = ""
-        "Redumper_win-x86"     = "https://github.com/superg/redumper/releases/download/build_597/redumper-2025.05.30_build597-Windows32.zip"
-        "Redumper_win-x64"     = "https://github.com/superg/redumper/releases/download/build_597/redumper-2025.05.30_build597-Windows64.zip"
+        "Redumper_win-x86"     = "https://github.com/superg/redumper/releases/download/build_610/redumper-2025.06.12_build610-Windows32.zip"
+        "Redumper_win-x64"     = "https://github.com/superg/redumper/releases/download/build_610/redumper-2025.06.12_build610-Windows64.zip"
     }
 
     # Download and extract files


### PR DESCRIPTION
Simple update. This build of redumper may be the minimum build required for non-plextor dumps going forward.