### PR TITLE
Suppress unnecessary write offset display when using DIC

### DIFF
--- a/MPF.Processors/DiscImageCreator.cs
+++ b/MPF.Processors/DiscImageCreator.cs
@@ -2176,7 +2176,7 @@ namespace MPF.Processors
 #endif
 
                 // Now that we're at the offsets, attempt to get the sample offset
-                return string.Join("; ", [.. offsets]);
+                return offsets.Count == 0 ? null : string.Join("; ", [.. offsets]);
             }
             catch
             {


### PR DESCRIPTION
This issue occurs with media that do not have a write offset, such as DVDs and BDs.

```
Data Side Mastering Code (laser branded/etched): (REQUIRED, IF EXISTS)
Data Side Mastering SID Code: (REQUIRED, IF EXISTS)
Data Side Toolstamp or Mastering Code (engraved/stamped): (REQUIRED, IF EXISTS)
Data Side Mould SID Code: (REQUIRED, IF EXISTS)
Data Side Additional Mould: (REQUIRED, IF EXISTS)
Label Side Mould SID Code: (REQUIRED, IF EXISTS)
Write Offset:  👈️
```
