### PR TITLE
redumper multisession .cache

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -18,6 +18,7 @@
 - Minor cleanup
 - Update test Nuget packages
 - Update RedumpLib to 1.7.1
+- Support multisession cache files
 
 ### 3.3.3 (2025-07-18)
 

--- a/MPF.Processors.Test/RedumperTests.cs
+++ b/MPF.Processors.Test/RedumperTests.cs
@@ -103,7 +103,7 @@ namespace MPF.Processors.Test
             var processor = new Redumper(RedumpSystem.IBMPCcompatible);
 
             var actual = processor.GetOutputFiles(MediaType.CDROM, outputDirectory, outputFilename);
-            Assert.Equal(16, actual.Count);
+            Assert.Equal(17, actual.Count);
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace MPF.Processors.Test
             var processor = new Redumper(RedumpSystem.IBMPCcompatible);
 
             var actual = processor.GetOutputFiles(MediaType.DVD, outputDirectory, outputFilename);
-            Assert.Equal(17, actual.Count);
+            Assert.Equal(15, actual.Count);
         }
 
         [Fact]

--- a/MPF.Processors/Redumper.cs
+++ b/MPF.Processors/Redumper.cs
@@ -445,9 +445,12 @@ namespace MPF.Processors
                         new($"{outputFilename}.atip", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "atip"),
-                        new($"{outputFilename}.cache", OutputFileFlags.Binary
+                        new([$"{outputFilename}.cache", $"{outputFilename}.1.cache"], OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "cache"),
+                        new($"{outputFilename}.2.cache", OutputFileFlags.Binary
+                            | OutputFileFlags.Zippable,
+                            "cache_2"),
                         new($"{outputFilename}.cdtext", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "cdtext"),
@@ -531,13 +534,6 @@ namespace MPF.Processors
                 case MediaType.NintendoGameCubeGameDisc:
                 case MediaType.NintendoWiiOpticalDisc:
                     return [
-                        // .asus is obsolete: newer redumper produces .cache instead
-                        new($"{outputFilename}.asus", OutputFileFlags.Binary
-                            | OutputFileFlags.Zippable,
-                            "asus"),
-                        new($"{outputFilename}.cache", OutputFileFlags.Binary
-                            | OutputFileFlags.Zippable,
-                            "cache"),
                         new($"{outputFilename}.dmi", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "dmi"),
@@ -577,6 +573,7 @@ namespace MPF.Processors
                         new($"{outputFilename}.ss", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "ss"),
+                        // ssv1 and ssv2 extensions are obsolete
                         new($"{outputFilename}.ssv1", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "ssv1"),


### PR DESCRIPTION
For multisession CDs, .cache file is split into .1.cache and .2.cache
DVDs also never generate .asus or .cache