### PR TITLE
Update DIC to 20250901 (Windows/Linux only)

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -19,6 +19,7 @@
 - Update test Nuget packages
 - Update RedumpLib to 1.7.1
 - Support multisession cache files
+- Update DIC to 20250901 (Windows/Linux only)
 
 ### 3.3.3 (2025-07-18)
 

--- a/publish-nix.sh
+++ b/publish-nix.sh
@@ -91,12 +91,12 @@ function download_programs() {
 
     # DiscImageCreator
     DL_MAP["Creator_linux-arm64"]=""
-    DL_MAP["Creator_linux-x64"]="https://github.com/user-attachments/files/20000183/DiscImageCreator_20250501.tar.gz"
+    DL_MAP["Creator_linux-x64"]="https://github.com/user-attachments/files/22080484/DiscImageCreator_20250901.tar.gz"
     DL_MAP["Creator_osx-arm64"]="https://github.com/user-attachments/files/20000184/DiscImageCreator_20250501.zip"
     DL_MAP["Creator_osx-x64"]="https://github.com/user-attachments/files/20000184/DiscImageCreator_20250501.zip"
     DL_MAP["Creator_win-arm64"]=""
-    DL_MAP["Creator_win-x86"]="https://github.com/user-attachments/files/20000181/DiscImageCreator_20250501.zip"
-    DL_MAP["Creator_win-x64"]="https://github.com/user-attachments/files/20000181/DiscImageCreator_20250501.zip"
+    DL_MAP["Creator_win-x86"]="https://github.com/user-attachments/files/22080480/DiscImageCreator_20250901.zip"
+    DL_MAP["Creator_win-x64"]="https://github.com/user-attachments/files/22080480/DiscImageCreator_20250901.zip"
 
     # Redumper
     DL_MAP["Redumper_linux-arm64"]="https://github.com/superg/redumper/releases/download/b653/redumper-b653-linux-arm64.zip"

--- a/publish-win.ps1
+++ b/publish-win.ps1
@@ -80,12 +80,12 @@ function Download-Programs {
 
         # DiscImageCreator
         "Creator_linux-arm64"  = ""
-        "Creator_linux-x64"    = "https://github.com/user-attachments/files/20000183/DiscImageCreator_20250501.tar.gz"
+        "Creator_linux-x64"    = "https://github.com/user-attachments/files/22080484/DiscImageCreator_20250901.tar.gz"
         "Creator_osx-arm64"    = "https://github.com/user-attachments/files/20000184/DiscImageCreator_20250501.zip"
         "Creator_osx-x64"      = "https://github.com/user-attachments/files/20000184/DiscImageCreator_20250501.zip"
         "Creator_win-arm64"    = ""
-        "Creator_win-x86"      = "https://github.com/user-attachments/files/20000181/DiscImageCreator_20250501.zip"
-        "Creator_win-x64"      = "https://github.com/user-attachments/files/20000181/DiscImageCreator_20250501.zip"
+        "Creator_win-x86"      = "https://github.com/user-attachments/files/22080480/DiscImageCreator_20250901.zip"
+        "Creator_win-x64"      = "https://github.com/user-attachments/files/22080480/DiscImageCreator_20250901.zip"
 
         # Redumper
         "Redumper_linux-arm64" = "https://github.com/superg/redumper/releases/download/b653/redumper-b653-linux-arm64.zip"


### PR DESCRIPTION
Update to latest DIC: https://github.com/saramibreak/DiscImageCreator/releases/tag/20250901
No mac build was provided, so macOS is still on 20250501