### PR TITLE
Remove SkipMediaTypeDetection option, cleanup options window

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -8,6 +8,7 @@
 - Update media type visibility on system change
 - Return full result from dump checks
 - Fix logic from around Macrovision security driver filtering
+- Remove SkipMediaTypeDetection option, cleanup options window
 
 ### 3.4.0 (2025-09-25)
 

--- a/MPF.Frontend/Options.cs
+++ b/MPF.Frontend/Options.cs
@@ -580,15 +580,6 @@ namespace MPF.Frontend
         #region Skip Options
 
         /// <summary>
-        /// Skip detecting media type on disc scan
-        /// </summary>
-        public bool SkipMediaTypeDetection
-        {
-            get { return GetBooleanSetting(Settings, "SkipMediaTypeDetection", false); }
-            set { Settings["SkipMediaTypeDetection"] = value.ToString(); }
-        }
-
-        /// <summary>
         /// Skip detecting known system on disc scan
         /// </summary>
         public bool SkipSystemDetection

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1213,13 +1213,12 @@ namespace MPF.Frontend.ViewModels
             if (defaultMediaType == MediaType.NONE)
                 defaultMediaType = MediaType.CDROM;
 
-            // If we're skipping detection, set the default value
-            if (Options.SkipMediaTypeDetection)
+            // Skip detection if not using DIC (only DIC needs to know media type)
+            if (Options.InternalProgram != InternalProgram.DiscImageCreator)
             {
-                VerboseLogLn($"Media type detection disabled, defaulting to {defaultMediaType.LongName()}.");
                 CurrentMediaType = defaultMediaType;
             }
-            // If the drive is marked active, try to read from it
+            // If using DIC and if the drive is marked active, try to read from it
             else if (CurrentDrive.MarkedActive)
             {
                 VerboseLog($"Trying to detect media type for drive {CurrentDrive.Name} [{CurrentDrive.DriveFormat}] using size and filesystem.. ");
@@ -1238,7 +1237,6 @@ namespace MPF.Frontend.ViewModels
                     CurrentMediaType = detectedMediaType;
                 }
             }
-
             // All other cases, just use the default
             else
             {

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1213,13 +1213,8 @@ namespace MPF.Frontend.ViewModels
             if (defaultMediaType == MediaType.NONE)
                 defaultMediaType = MediaType.CDROM;
 
-            // Skip detection if not using DIC (only DIC needs to know media type)
-            if (Options.InternalProgram != InternalProgram.DiscImageCreator)
-            {
-                CurrentMediaType = defaultMediaType;
-            }
-            // If using DIC and if the drive is marked active, try to read from it
-            else if (CurrentDrive.MarkedActive)
+            // If the drive is marked active, try to read from it
+            if (CurrentDrive.MarkedActive)
             {
                 VerboseLog($"Trying to detect media type for drive {CurrentDrive.Name} [{CurrentDrive.DriveFormat}] using size and filesystem.. ");
                 MediaType? detectedMediaType = CurrentDrive.GetMediaType(CurrentSystem);
@@ -1237,7 +1232,7 @@ namespace MPF.Frontend.ViewModels
                     CurrentMediaType = detectedMediaType;
                 }
             }
-            // All other cases, just use the default
+            // Otherwise just use the default
             else
             {
                 VerboseLogLn($"Drive marked as empty, defaulting to {defaultMediaType.LongName()}.");

--- a/MPF.UI/Windows/OptionsWindow.xaml
+++ b/MPF.UI/Windows/OptionsWindow.xaml
@@ -95,7 +95,7 @@
                         </GroupBox>
 
                         <GroupBox Margin="5,5,5,5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Header="Detection">
-                            <UniformGrid Columns="2" Rows="3">
+                            <UniformGrid Columns="2" Rows="2">
                                 <CheckBox VerticalAlignment="Center" Content="Skip System Detect"
                                           IsChecked="{Binding Options.SkipSystemDetection}"
                                           ToolTip="Disable trying to guess system (may improve performance at startup)" Margin="0,4"

--- a/MPF.UI/Windows/OptionsWindow.xaml
+++ b/MPF.UI/Windows/OptionsWindow.xaml
@@ -96,21 +96,15 @@
 
                         <GroupBox Margin="5,5,5,5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Header="Detection">
                             <UniformGrid Columns="2" Rows="3">
-                                <CheckBox x:Name="SkipMediaTypeDetectionCheckBox" VerticalAlignment="Center" Content="Skip Type Detect"
-                                          IsChecked="{Binding Options.SkipMediaTypeDetection}"
-                                          ToolTip="Disable trying to guess media type inserted (may improve performance at startup)" Margin="0,4"
-                                />
-
                                 <CheckBox VerticalAlignment="Center" Content="Skip System Detect"
                                           IsChecked="{Binding Options.SkipSystemDetection}"
                                           ToolTip="Disable trying to guess system (may improve performance at startup)" Margin="0,4"
                                 />
 
                                 <CheckBox VerticalAlignment="Center" Content="No Fixed Drives"
-                                        IsChecked="{Binding Options.IgnoreFixedDrives}"
-                                        ToolTip="Ignore hard drives and other fixed drives" Margin="0,4"
+                                          IsChecked="{Binding Options.IgnoreFixedDrives}"
+                                          ToolTip="Ignore hard drives and other fixed drives" Margin="0,4"
                                 />
-                                <Label/> <!-- Empty label for padding -->
 
                                 <Label VerticalAlignment="Center" Content="Default System:" HorizontalAlignment="Right" />
                                 <ComboBox x:Name="DefaultSystemComboBox" Height="22" Width="200" HorizontalAlignment="Left"
@@ -413,7 +407,11 @@
                                           IsChecked="{Binding Options.RedumperEnableVerbose}"
                                           ToolTip="Enable verbose output in logs" Margin="0,4"
                                 />
-                                <Label/> <!-- Empty label for padding -->
+
+                                <CheckBox VerticalAlignment="Center" Content="Enable Refine Sector Mode Flag"
+                                          IsChecked="{Binding Options.RedumperRefineSectorMode}"
+                                          ToolTip="Enable the refine sector mode flag by default" Margin="0,4"
+                                />
 
                                 <Label Content="Reread Tries:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                                 <TextBox VerticalAlignment="Center" VerticalContentAlignment="Center" Width="200" HorizontalAlignment="Left"
@@ -427,12 +425,6 @@
                                          ToolTip="Specifies how many retries are attempted for lead-in on Plextor drives"
                                          ToolTipService.ShowOnDisabled="True"
                                 />
-
-                                <CheckBox VerticalAlignment="Center" Content="Enable Refine Sector Mode Flag"
-                                          IsChecked="{Binding Options.RedumperRefineSectorMode}"
-                                          ToolTip="Enable the refine sector mode flag by default" Margin="0,4"
-                                />
-                                <Label/> <!-- Empty label for padding -->
 
                                 <CheckBox VerticalAlignment="Center" Content="Non-Redump Options" Click="NonRedumpModeClicked"
                                           IsChecked="{Binding Options.RedumperNonRedumpMode}"
@@ -483,7 +475,8 @@
                                     IsEnabled="{Binding Options.RetrieveMatchInformation}" />
 
                                 <Label VerticalAlignment="Center" HorizontalAlignment="Right" Content="Password" />
-                                <PasswordBox x:Name="RedumpPasswordBox" Height="22" HorizontalAlignment="Stretch" PasswordChar="*" />
+                                <PasswordBox x:Name="RedumpPasswordBox" Height="22" HorizontalAlignment="Stretch" PasswordChar="*"
+                                             IsEnabled="{Binding Options.RetrieveMatchInformation}"/>
 
                                 <Button x:Name="RedumpLoginTestButton" Height="22" Width="80" Content="Test Login"
                                         Style="{DynamicResource CustomButtonStyle}"


### PR DESCRIPTION
`SkipMediaTypeDetection` option is now mostly obsolete, so this PR removes it.
Unlike long ago, MPF no longer uses the old third party library (no chance of freezing the UI so there is no essential need for the option).
And as of recently, only DIC execution context cares about the media type, so I have replaced the option with a check against Internal Program. Media type detection now runs only when DIC is selected.

Additionally, a couple of minor UI fixes have been made in the Options window.