### PR TITLE
Support new redumper log for current profile

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -41,6 +41,7 @@
 - Update Aaru to 5.4.2 LTS
 - Use prefixing protection scan output
 - Print error when redump is down
+- Support new redumper log for current profile
 
 ### 3.6.0 (2025-11-28)
 

--- a/MPF.Processors/Redumper.cs
+++ b/MPF.Processors/Redumper.cs
@@ -993,6 +993,17 @@ namespace MPF.Processors
 #endif
                     }
 
+                    // The profile is listed in a single line
+                    if (line.StartsWith("profile:"))
+                    {
+                        // current profile: <discType>
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                        discProfile = line["profile: ".Length..];
+#else
+                        discProfile = line.Substring("profile: ".Length);
+#endif
+                    }
+
                     line = sr.ReadLine();
                 }
 


### PR DESCRIPTION
This **doesn't** officially support new redumper builds, but it does mean they don't break completely because of the new disc type printout.
I've only added code, this is fully backwards compatible with old redumper.
So I haven't bumped redumper version yet, that will require adding `--rings` option, new `MTK2B` drive type, .sdram output file, and GC/Wii system support.