### PR TITLE
Add Disc Hologram ID placeholders for all Xbox discs

### DIFF
--- a/MPF.Frontend/Tools/SubmissionGenerator.cs
+++ b/MPF.Frontend/Tools/SubmissionGenerator.cs
@@ -906,12 +906,19 @@ namespace MPF.Frontend.Tools
                     info.CommonDiscInfo.EXEDateBuildDate ??= addPlaceholders ? RequiredValue : string.Empty;
                     break;
 
+                case RedumpSystem.MicrosoftXbox:
+                case RedumpSystem.MicrosoftXbox360:
+                    info.CommonDiscInfo.CommentsSpecialFields[SiteCode.DiscHologramID] ??= addPlaceholders ? RequiredIfExistsValue : string.Empty;
+                    break;
+
                 case RedumpSystem.MicrosoftXboxOne:
+                    info.CommonDiscInfo.CommentsSpecialFields[SiteCode.DiscHologramID] ??= addPlaceholders ? RequiredIfExistsValue : string.Empty;
                     info.CommonDiscInfo.CommentsSpecialFields[SiteCode.Filename] = PhysicalTool.GetXboxFilenames(drive) ?? string.Empty;
                     info.CommonDiscInfo.CommentsSpecialFields[SiteCode.TitleID] = PhysicalTool.GetXboxTitleID(drive) ?? string.Empty;
                     break;
 
                 case RedumpSystem.MicrosoftXboxSeriesXS:
+                    info.CommonDiscInfo.CommentsSpecialFields[SiteCode.DiscHologramID] ??= addPlaceholders ? RequiredIfExistsValue : string.Empty;
                     info.CommonDiscInfo.CommentsSpecialFields[SiteCode.Filename] = PhysicalTool.GetXboxFilenames(drive) ?? string.Empty;
                     info.CommonDiscInfo.CommentsSpecialFields[SiteCode.TitleID] = PhysicalTool.GetXboxTitleID(drive) ?? string.Empty;
                     break;


### PR DESCRIPTION
I don't have a dotnet build setup to test this, but this should work. 

~~I don't believe original xbox discs have this ID, based on the 30 or so redump entries I checked as well as the discs I personally own?~~ apparently some do