### PR TITLE
Convert type of reports from success to neutral for essential steps

### DIFF
--- a/MPF.Frontend/Tools/SubmissionGenerator.cs
+++ b/MPF.Frontend/Tools/SubmissionGenerator.cs
@@ -214,7 +214,7 @@ namespace MPF.Frontend.Tools
                 }
                 else
                 {
-                    resultProgress?.Report(ResultEventArgs.Success("Successfully logged into Redump!"));
+                    resultProgress?.Report(ResultEventArgs.Neutral("Successfully logged into Redump!"));
                 }
             }
 
@@ -358,7 +358,7 @@ namespace MPF.Frontend.Tools
             info.PartiallyMatchedIDs = [.. partiallyMatchedIds];
             info.PartiallyMatchedIDs.Sort();
 
-            resultProgress?.Report(ResultEventArgs.Success("Match finding complete! " + (fullyMatchedIdsList is not null && fullyMatchedIdsList.Count > 0
+            resultProgress?.Report(ResultEventArgs.Neutral("Match finding complete! " + (fullyMatchedIdsList is not null && fullyMatchedIdsList.Count > 0
                 ? "Fully Matched IDs: " + string.Join(",", [.. fullyMatchedIdsList.ConvertAll(i => i.ToString())])
                 : "No matches found")));
 


### PR DESCRIPTION
```
SUCCESS: Successfully logged into Redump!
Finding disc matches on Redump, this might take a while... 
FAILURE: No matches found for xyz
SUCCESS: Match finding complete! No matches found
```

In current form word FAILURE "disappears" between  2 SUCCESSes, imho removing them would increase readability of log from MPF.CLI. (as long as this doesn't break anything)

Just a random idea I got during dumping, feel free to close if you have different opinion.