### PR TITLE
Fix trailing newline trimming for cue import

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -16,6 +16,7 @@
 - Separate BEE
 - Convert type of reports from success to neutral for essential steps (shfil119)
 - Subtract fixed SCSI errors
+- Fix trailing newline trimming for cue import (fuzz6001)
 
 ### 3.7.1 (2026-03-30)
 

--- a/MPF.Processors/Redumper.cs
+++ b/MPF.Processors/Redumper.cs
@@ -1050,7 +1050,7 @@ namespace MPF.Processors
                     line = sr.ReadLine();
                 }
 
-                return sb.ToString().TrimEnd('\n');
+                return sb.ToString().TrimEnd('\r', '\n');
             }
             catch
             {


### PR DESCRIPTION
Cue entries imported from redumper logs retained a trailing `\r`.
This PR updates the cue import process so that trailing CRLF line endings
are removed correctly.

before - after
<img width="1150" height="122" alt="cue_diff" src="https://github.com/user-attachments/assets/d4e103dd-69a2-4c2a-bd05-cdb92531a552" />
