### PR TITLE
Preserve redumper log file

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -26,6 +26,7 @@
 - Tweak wording on no protections found
 - Fix typo in Check help text
 - Use human-readable names in interactive modes
+- Preserve redumper log file
 
 ### 3.7.1 (2026-03-30)
 

--- a/MPF.Processors.Test/RedumperTests.cs
+++ b/MPF.Processors.Test/RedumperTests.cs
@@ -301,7 +301,7 @@ namespace MPF.Processors.Test
             string outputFilename = "test.cue";
             var processor = new Redumper(RedumpSystem.IBMPCcompatible);
             var actual = processor.GetPreservedFilePaths(MediaType.CDROM, outputDirectory, outputFilename);
-            Assert.Equal(2, actual.Count());
+            Assert.Equal(2, actual.Count);
             Assert.Contains(Path.Combine(outputDirectory, "test.cue"), actual);
             Assert.Contains(Path.Combine(outputDirectory, "test.log"), actual);
         }

--- a/MPF.Processors.Test/RedumperTests.cs
+++ b/MPF.Processors.Test/RedumperTests.cs
@@ -301,7 +301,9 @@ namespace MPF.Processors.Test
             string outputFilename = "test.cue";
             var processor = new Redumper(RedumpSystem.IBMPCcompatible);
             var actual = processor.GetPreservedFilePaths(MediaType.CDROM, outputDirectory, outputFilename);
-            Assert.Single(actual);
+            Assert.Equal(2, actual.Count());
+            Assert.Contains(Path.Combine(outputDirectory, "test.cue"), actual);
+            Assert.Contains(Path.Combine(outputDirectory, "test.log"), actual);
         }
 
         #endregion

--- a/MPF.Processors/Redumper.cs
+++ b/MPF.Processors/Redumper.cs
@@ -564,7 +564,8 @@ namespace MPF.Processors
                             "fulltoc"),
                         new($"{outputFilename}.log", OutputFileFlags.Required
                             | OutputFileFlags.Artifact
-                            | OutputFileFlags.Zippable,
+                            | OutputFileFlags.Zippable
+                            | OutputFileFlags.Preserve,
                             "log"),
                         new CustomOutputFile([$"{outputFilename}.dat", $"{outputFilename}.log"], OutputFileFlags.Required,
                             DatfileExists),


### PR DESCRIPTION
Redumper log file should be zipped, but also kept in the dump directory so dumpers don't lose track of it for submission.