### PR TITLE
Resolve bare dumping-tool names via runtime directory and PATH

### DIFF
--- a/MPF.CLI/Features/BaseFeature.cs
+++ b/MPF.CLI/Features/BaseFeature.cs
@@ -146,19 +146,29 @@ namespace MPF.CLI.Features
             switch (Options.InternalProgram)
             {
                 case InternalProgram.Aaru:
-                    if (!File.Exists(Options.Dumping.AaruPath))
                     {
-                        Console.Error.WriteLine("A path needs to be supplied in config.json for Aaru, exiting...");
-                        return false;
+                        string? resolved = FrontendTool.ResolveBinaryPath(Options.Dumping.AaruPath);
+                        if (resolved == null)
+                        {
+                            Console.Error.WriteLine("A path needs to be supplied in config.json for Aaru, exiting...");
+                            return false;
+                        }
+
+                        Options.Dumping.AaruPath = resolved;
                     }
 
                     break;
 
                 case InternalProgram.DiscImageCreator:
-                    if (!File.Exists(Options.Dumping.DiscImageCreatorPath))
                     {
-                        Console.Error.WriteLine("A path needs to be supplied in config.json for DIC, exiting...");
-                        return false;
+                        string? resolved = FrontendTool.ResolveBinaryPath(Options.Dumping.DiscImageCreatorPath);
+                        if (resolved == null)
+                        {
+                            Console.Error.WriteLine("A path needs to be supplied in config.json for DIC, exiting...");
+                            return false;
+                        }
+
+                        Options.Dumping.DiscImageCreatorPath = resolved;
                     }
 
                     break;
@@ -173,10 +183,15 @@ namespace MPF.CLI.Features
                 //     break;
 
                 case InternalProgram.Redumper:
-                    if (!File.Exists(Options.Dumping.RedumperPath))
                     {
-                        Console.Error.WriteLine("A path needs to be supplied in config.json for Redumper, exiting...");
-                        return false;
+                        string? resolved = FrontendTool.ResolveBinaryPath(Options.Dumping.RedumperPath);
+                        if (resolved == null)
+                        {
+                            Console.Error.WriteLine("A path needs to be supplied in config.json for Redumper, exiting...");
+                            return false;
+                        }
+
+                        Options.Dumping.RedumperPath = resolved;
                     }
 
                     break;

--- a/MPF.Frontend.Test/Tools/FrontendToolTests.cs
+++ b/MPF.Frontend.Test/Tools/FrontendToolTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using MPF.Frontend.Tools;
 using SabreTools.RedumpLib.Data;
 using Xunit;
@@ -58,6 +60,96 @@ namespace MPF.Frontend.Test.Tools
 
         // TODO: Write NormalizeDiscTitle(string?, Language?[]?) test
         // TODO: Write NormalizeDiscTitle(string?, Language?) test
+
+        #endregion
+
+        #region ResolveBinaryPath
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ResolveBinaryPath_NullOrEmpty_ReturnsNull(string? input)
+        {
+            Assert.Null(FrontendTool.ResolveBinaryPath(input));
+        }
+
+        [Fact]
+        public void ResolveBinaryPath_AbsolutePathExists_ReturnsAsIs()
+        {
+            // Use this assembly's location — guaranteed to exist on disk.
+            string self = typeof(FrontendToolTests).Assembly.Location;
+            Assert.Equal(self, FrontendTool.ResolveBinaryPath(self));
+        }
+
+        [Fact]
+        public void ResolveBinaryPath_AbsolutePathMissing_ReturnsNull()
+        {
+            string missing = Path.Combine(Path.GetTempPath(), $"mpf-test-{Guid.NewGuid():N}.bin");
+            Assert.False(File.Exists(missing));
+            Assert.Null(FrontendTool.ResolveBinaryPath(missing));
+        }
+
+        [Fact]
+        public void ResolveBinaryPath_RelativePathSeparator_ReturnsNullWhenMissing()
+        {
+            // Contains a separator → treated as explicit path, not searched on PATH.
+            string relative = Path.Combine("definitely-not-a-dir", $"mpf-test-{Guid.NewGuid():N}.bin");
+            Assert.Null(FrontendTool.ResolveBinaryPath(relative));
+        }
+
+        [Fact]
+        public void ResolveBinaryPath_BareName_FoundInRuntimeDirectory()
+        {
+            // Create a file in the test assembly's runtime directory; the bare-name lookup
+            // should find it via the runtime-directory probe.
+            string runtimeDir = AppContext.BaseDirectory;
+            string fileName = $"mpf-test-{Guid.NewGuid():N}.bin";
+            string fullPath = Path.Combine(runtimeDir, fileName);
+
+            File.WriteAllBytes(fullPath, Array.Empty<byte>());
+            try
+            {
+                string? resolved = FrontendTool.ResolveBinaryPath(fileName);
+                Assert.Equal(fullPath, resolved);
+            }
+            finally
+            {
+                File.Delete(fullPath);
+            }
+        }
+
+        [Fact]
+        public void ResolveBinaryPath_BareName_FoundOnPath()
+        {
+            // Stage a file in a temporary directory, prepend it to PATH, and ensure
+            // bare-name resolution picks it up after the runtime-dir probe misses.
+            string tempDir = Path.Combine(Path.GetTempPath(), $"mpf-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            string fileName = $"mpf-test-{Guid.NewGuid():N}.bin";
+            string fullPath = Path.Combine(tempDir, fileName);
+            File.WriteAllBytes(fullPath, Array.Empty<byte>());
+
+            string? originalPath = Environment.GetEnvironmentVariable("PATH");
+            try
+            {
+                Environment.SetEnvironmentVariable("PATH", tempDir + Path.PathSeparator + (originalPath ?? string.Empty));
+                string? resolved = FrontendTool.ResolveBinaryPath(fileName);
+                Assert.Equal(fullPath, resolved);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("PATH", originalPath);
+                File.Delete(fullPath);
+                Directory.Delete(tempDir);
+            }
+        }
+
+        [Fact]
+        public void ResolveBinaryPath_BareName_NotFound_ReturnsNull()
+        {
+            string fileName = $"mpf-test-{Guid.NewGuid():N}-not-real.bin";
+            Assert.Null(FrontendTool.ResolveBinaryPath(fileName));
+        }
 
         #endregion
     }

--- a/MPF.Frontend/Tools/FrontendTool.cs
+++ b/MPF.Frontend/Tools/FrontendTool.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Reflection;
 using System.Text;
 using SabreTools.RedumpLib.Data;
@@ -102,6 +103,86 @@ namespace MPF.Frontend.Tools
                 return RedumpSystem.SonyPlayStation5;
 
             return null;
+        }
+
+        #endregion
+
+        #region Binary Resolution
+
+        /// <summary>
+        /// Resolve a configured dumping-tool path to an absolute file path.
+        /// </summary>
+        /// <param name="configuredPath">Raw value from the user's options (Aaru/DIC/Redumper path)</param>
+        /// <returns>
+        /// The absolute path of the located binary, or <c>null</c> when nothing exists.
+        /// <para>
+        /// Behavior:
+        /// <list type="bullet">
+        /// <item>null/empty input → null.</item>
+        /// <item>contains a path separator → treated as an explicit location; returned as-is if
+        ///       <see cref="File.Exists(string)"/> matches, otherwise null. Preserves the
+        ///       pre-existing behavior for users that configure absolute or relative paths.</item>
+        /// <item>bare executable name (no separator) → searched in the runtime directory first,
+        ///       then in each <c>$PATH</c> entry. The runtime-directory probe lets a frontend
+        ///       bundle ship its dumping tools alongside the binary; the <c>$PATH</c> probe lets
+        ///       distro-installed tools (e.g. <c>/usr/bin/redumper</c>) be picked up automatically.
+        ///       Returns the first existing match or null.</item>
+        /// </list>
+        /// </para>
+        /// </returns>
+        /// <remarks>
+        /// Matches the design agreed on in
+        /// <see href="https://github.com/SabreTools/MPF/pull/856">#856</see>:
+        /// a path with separators is treated as the explicit location it always has been; a bare
+        /// name opts the user in to a runtime-dir / <c>$PATH</c> lookup.
+        /// </remarks>
+        public static string? ResolveBinaryPath(string? configuredPath)
+        {
+            if (string.IsNullOrEmpty(configuredPath))
+                return null;
+
+            // Explicit location (absolute or relative path) — keep historical behavior.
+            if (configuredPath!.IndexOf('/') >= 0 || configuredPath.IndexOf('\\') >= 0)
+                return File.Exists(configuredPath) ? configuredPath : null;
+
+            // Bare name — search runtime directory first, then $PATH.
+            string runtimeDir = GetRuntimeDirectory();
+            if (!string.IsNullOrEmpty(runtimeDir))
+            {
+                string candidate = Path.Combine(runtimeDir, configuredPath);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+
+            string? pathEnv = Environment.GetEnvironmentVariable("PATH");
+            if (string.IsNullOrEmpty(pathEnv))
+                return null;
+
+            foreach (string dir in pathEnv!.Split(Path.PathSeparator))
+            {
+                if (string.IsNullOrEmpty(dir))
+                    continue;
+
+                string candidate = Path.Combine(dir, configuredPath);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Directory containing the running application; used as the first lookup root for
+        /// bare-name binaries (see <see cref="ResolveBinaryPath(string?)"/>). Matches the
+        /// multi-TFM pattern already used in <c>OptionsLoader.GetRuntimeConfigurationPath</c>.
+        /// </summary>
+        private static string GetRuntimeDirectory()
+        {
+#if NET20 || NET35 || NET40 || NET452
+            return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
+#else
+            return AppContext.BaseDirectory;
+#endif
         }
 
         #endregion

--- a/MPF.Frontend/Tools/FrontendTool.cs
+++ b/MPF.Frontend/Tools/FrontendTool.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Text;
+using SabreTools.IO;
 using SabreTools.RedumpLib.Data;
 
 namespace MPF.Frontend.Tools
@@ -112,41 +113,24 @@ namespace MPF.Frontend.Tools
         /// <summary>
         /// Resolve a configured dumping-tool path to an absolute file path.
         /// </summary>
-        /// <param name="configuredPath">Raw value from the user's options (Aaru/DIC/Redumper path)</param>
+        /// <param name="configuredPath">Raw value from the user's options</param>
         /// <returns>
-        /// The absolute path of the located binary, or <c>null</c> when nothing exists.
-        /// <para>
-        /// Behavior:
-        /// <list type="bullet">
-        /// <item>null/empty input → null.</item>
-        /// <item>contains a path separator → treated as an explicit location; returned as-is if
-        ///       <see cref="File.Exists(string)"/> matches, otherwise null. Preserves the
-        ///       pre-existing behavior for users that configure absolute or relative paths.</item>
-        /// <item>bare executable name (no separator) → searched in the runtime directory first,
-        ///       then in each <c>$PATH</c> entry. The runtime-directory probe lets a frontend
-        ///       bundle ship its dumping tools alongside the binary; the <c>$PATH</c> probe lets
-        ///       distro-installed tools (e.g. <c>/usr/bin/redumper</c>) be picked up automatically.
-        ///       Returns the first existing match or null.</item>
-        /// </list>
-        /// </para>
+        /// The absolute path of the located binary, or null when nothing exists.
+        /// A value containing a path separator is treated as an explicit location and
+        /// returned as-is when it exists. A bare name (no separator) is searched in the
+        /// runtime directory first, then in each PATH entry.
         /// </returns>
-        /// <remarks>
-        /// Matches the design agreed on in
-        /// <see href="https://github.com/SabreTools/MPF/pull/856">#856</see>:
-        /// a path with separators is treated as the explicit location it always has been; a bare
-        /// name opts the user in to a runtime-dir / <c>$PATH</c> lookup.
-        /// </remarks>
         public static string? ResolveBinaryPath(string? configuredPath)
         {
             if (string.IsNullOrEmpty(configuredPath))
                 return null;
 
             // Explicit location (absolute or relative path) — keep historical behavior.
-            if (configuredPath!.IndexOf('/') >= 0 || configuredPath.IndexOf('\\') >= 0)
+            if (configuredPath!.Contains("/") || configuredPath.Contains("\\"))
                 return File.Exists(configuredPath) ? configuredPath : null;
 
             // Bare name — search runtime directory first, then $PATH.
-            string runtimeDir = GetRuntimeDirectory();
+            string runtimeDir = PathTool.GetRuntimeDirectory();
             if (!string.IsNullOrEmpty(runtimeDir))
             {
                 string candidate = Path.Combine(runtimeDir, configuredPath);
@@ -169,20 +153,6 @@ namespace MPF.Frontend.Tools
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Directory containing the running application; used as the first lookup root for
-        /// bare-name binaries (see <see cref="ResolveBinaryPath(string?)"/>). Matches the
-        /// multi-TFM pattern already used in <c>OptionsLoader.GetRuntimeConfigurationPath</c>.
-        /// </summary>
-        private static string GetRuntimeDirectory()
-        {
-#if NET20 || NET35 || NET40 || NET452
-            return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
-#else
-            return AppContext.BaseDirectory;
-#endif
         }
 
         #endregion

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -2458,10 +2458,10 @@ namespace MPF.Frontend.ViewModels
 #pragma warning disable IDE0072
                 return program switch
                 {
-                    InternalProgram.Aaru => File.Exists(Options.Dumping.AaruPath),
-                    InternalProgram.DiscImageCreator => File.Exists(Options.Dumping.DiscImageCreatorPath),
-                    // InternalProgram.Dreamdump => File.Exists(Options.Dumping.DreamdumpPath),
-                    InternalProgram.Redumper => File.Exists(Options.Dumping.RedumperPath),
+                    InternalProgram.Aaru => FrontendTool.ResolveBinaryPath(Options.Dumping.AaruPath) != null,
+                    InternalProgram.DiscImageCreator => FrontendTool.ResolveBinaryPath(Options.Dumping.DiscImageCreatorPath) != null,
+                    // InternalProgram.Dreamdump => FrontendTool.ResolveBinaryPath(Options.Dumping.DreamdumpPath) != null,
+                    InternalProgram.Redumper => FrontendTool.ResolveBinaryPath(Options.Dumping.RedumperPath) != null,
                     _ => false,
                 };
 #pragma warning restore IDE0072

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -1243,6 +1243,38 @@ namespace MPF.Frontend.ViewModels
         /// <returns>Filled DumpEnvironment Parent</returns>
         private DumpEnvironment DetermineEnvironment()
         {
+            // Mirror the CLI behavior: resolve the configured tool path through
+            // the runtime directory and PATH so that bare binary names work.
+            // Leave the configured value untouched when the path is not
+            // resolvable; ProcessStartInfo can still rely on its native PATH
+            // lookup for bare names.
+            switch (CurrentProgram)
+            {
+                case InternalProgram.Aaru:
+                    {
+                        string? resolved = FrontendTool.ResolveBinaryPath(Options.Dumping.AaruPath);
+                        if (resolved != null)
+                            Options.Dumping.AaruPath = resolved;
+                    }
+                    break;
+
+                case InternalProgram.DiscImageCreator:
+                    {
+                        string? resolved = FrontendTool.ResolveBinaryPath(Options.Dumping.DiscImageCreatorPath);
+                        if (resolved != null)
+                            Options.Dumping.DiscImageCreatorPath = resolved;
+                    }
+                    break;
+
+                case InternalProgram.Redumper:
+                    {
+                        string? resolved = FrontendTool.ResolveBinaryPath(Options.Dumping.RedumperPath);
+                        if (resolved != null)
+                            Options.Dumping.RedumperPath = resolved;
+                    }
+                    break;
+            }
+
             var env = new DumpEnvironment(
                 Options,
                 EvaluateOutputPath(OutputPath),


### PR DESCRIPTION
Resolves a configured dumping-tool path through the runtime directory and
`$PATH` when the value is a bare executable name, so distro-installed tools
(e.g. `/usr/bin/redumper`) are found without an absolute path in `config.json`.

### What this PR does
- Adds `FrontendTool.ResolveBinaryPath(string?)`: a value containing a path
  separator keeps the existing `File.Exists` behavior; a bare name (no
  separator) is looked up in the runtime directory first, then each `$PATH`
  entry.
- Wires it into the three existing call sites: the CLI (`BaseFeature`) and the
  GUI/ViewModel program-availability check and dump-environment setup
  (`MainViewModel`).
- Implements the design @mnadareski accepted in #856: "As long as it also
  looked at the runtime directory as well, then that is a reasonable
  alternative."

### What this PR doesn't do
- No assumed or hardcoded binary names — only the value the user already
  configured is resolved.
- No new environment variables (e.g. `MPF_*_PATH`).
- No PATHEXT handling: a bare name on Windows is matched verbatim. Default
  configs use path separators and hit the unchanged branch.
- No new dependencies.

### Tests
`MPF.Frontend.Test/Tools/FrontendToolTests.cs` — 8 cases: null/empty,
absolute-existing, absolute-missing, relative-with-separator missing, bare
name in runtime dir, bare name on `$PATH`, bare name not found.

Built net20 → net10.0, all green; full MPF.Frontend.Test suite passes (510).

This revives the approach from @leo60228's earlier `resolve-binary-path` PR,
extended to the CLI and ViewModel call sites. Happy to split, rebase, or strip
this down further if any of it is out of scope.

Prepared with AI assistance (Claude Opus 4.8) and reviewed before submission.
