### PR TITLE
Enumerate /dev/sr* optical drives on Linux

### DIFF
--- a/MPF.Frontend.Test/DriveTests.cs
+++ b/MPF.Frontend.Test/DriveTests.cs
@@ -55,5 +55,54 @@ namespace MPF.Frontend.Test
         }
 
         #endregion
+
+        #region EnumerateUnixOpticalDevicePaths
+
+        [Fact]
+        public void EnumerateUnixOpticalDevicePaths_NullOrEmpty_ReturnsEmpty()
+        {
+            Assert.Empty(Drive.EnumerateUnixOpticalDevicePaths(null!));
+            Assert.Empty(Drive.EnumerateUnixOpticalDevicePaths(string.Empty));
+        }
+
+        [Fact]
+        public void EnumerateUnixOpticalDevicePaths_MissingDirectory_ReturnsEmpty()
+        {
+            string missing = Path.Combine(Path.GetTempPath(), "mpf-test-missing-" + Guid.NewGuid().ToString("N"));
+            Assert.Empty(Drive.EnumerateUnixOpticalDevicePaths(missing));
+        }
+
+        [Fact]
+        public void EnumerateUnixOpticalDevicePaths_OnlyMatchesSrFollowedByDigits()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "mpf-test-dev-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            try
+            {
+                File.WriteAllText(Path.Combine(root, "sr0"), string.Empty);
+                File.WriteAllText(Path.Combine(root, "sr1"), string.Empty);
+                File.WriteAllText(Path.Combine(root, "sr15"), string.Empty);
+                File.WriteAllText(Path.Combine(root, "src"), string.Empty);
+                File.WriteAllText(Path.Combine(root, "srm"), string.Empty);
+                File.WriteAllText(Path.Combine(root, "serial0"), string.Empty);
+                File.WriteAllText(Path.Combine(root, "sr"), string.Empty);
+                File.WriteAllText(Path.Combine(root, "sr0a"), string.Empty);
+
+                var actual = Drive.EnumerateUnixOpticalDevicePaths(root);
+
+                var actualNames = new List<string>();
+                foreach (var p in actual)
+                    actualNames.Add(Path.GetFileName(p));
+                actualNames.Sort(StringComparer.Ordinal);
+
+                Assert.Equal(new[] { "sr0", "sr1", "sr15" }, actualNames);
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        #endregion
     }
 }

--- a/MPF.Frontend.Test/DriveTests.cs
+++ b/MPF.Frontend.Test/DriveTests.cs
@@ -56,24 +56,24 @@ namespace MPF.Frontend.Test
 
         #endregion
 
-        #region EnumerateUnixOpticalDevicePaths
+        #region EnumerateUnixOpticalBlockPaths
 
         [Fact]
-        public void EnumerateUnixOpticalDevicePaths_NullOrEmpty_ReturnsEmpty()
+        public void EnumerateUnixOpticalBlockPaths_NullOrEmpty_ReturnsEmpty()
         {
-            Assert.Empty(Drive.EnumerateUnixOpticalDevicePaths(null!));
-            Assert.Empty(Drive.EnumerateUnixOpticalDevicePaths(string.Empty));
+            Assert.Empty(Drive.EnumerateUnixOpticalBlockPaths(null!));
+            Assert.Empty(Drive.EnumerateUnixOpticalBlockPaths(string.Empty));
         }
 
         [Fact]
-        public void EnumerateUnixOpticalDevicePaths_MissingDirectory_ReturnsEmpty()
+        public void EnumerateUnixOpticalBlockPaths_MissingDirectory_ReturnsEmpty()
         {
             string missing = Path.Combine(Path.GetTempPath(), "mpf-test-missing-" + Guid.NewGuid().ToString("N"));
-            Assert.Empty(Drive.EnumerateUnixOpticalDevicePaths(missing));
+            Assert.Empty(Drive.EnumerateUnixOpticalBlockPaths(missing));
         }
 
         [Fact]
-        public void EnumerateUnixOpticalDevicePaths_OnlyMatchesSrFollowedByDigits()
+        public void EnumerateUnixOpticalBlockPaths_OnlyMatchesSrFollowedByDigits()
         {
             string root = Path.Combine(Path.GetTempPath(), "mpf-test-dev-" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(root);
@@ -88,7 +88,7 @@ namespace MPF.Frontend.Test
                 File.WriteAllText(Path.Combine(root, "sr"), string.Empty);
                 File.WriteAllText(Path.Combine(root, "sr0a"), string.Empty);
 
-                var actual = Drive.EnumerateUnixOpticalDevicePaths(root);
+                var actual = Drive.EnumerateUnixOpticalBlockPaths(root);
 
                 var actualNames = new List<string>();
                 foreach (var p in actual)
@@ -103,6 +103,71 @@ namespace MPF.Frontend.Test
             {
                 Directory.Delete(root, recursive: true);
             }
+        }
+
+        #endregion
+
+        #region EnumerateUnixOpticalGenericPaths
+
+        [Fact]
+        public void EnumerateUnixOpticalGenericPaths_NullOrEmpty_ReturnsEmpty()
+        {
+            Assert.Empty(Drive.EnumerateUnixOpticalGenericPaths(null!, "/sys/class/scsi_generic"));
+            Assert.Empty(Drive.EnumerateUnixOpticalGenericPaths(string.Empty, "/sys/class/scsi_generic"));
+            Assert.Empty(Drive.EnumerateUnixOpticalGenericPaths("/dev", null!));
+            Assert.Empty(Drive.EnumerateUnixOpticalGenericPaths("/dev", string.Empty));
+        }
+
+        [Fact]
+        public void EnumerateUnixOpticalGenericPaths_MissingDirectory_ReturnsEmpty()
+        {
+            string missing = Path.Combine(Path.GetTempPath(), "mpf-test-missing-" + Guid.NewGuid().ToString("N"));
+            Assert.Empty(Drive.EnumerateUnixOpticalGenericPaths("/dev", missing));
+        }
+
+        [Fact]
+        public void EnumerateUnixOpticalGenericPaths_OnlyMatchesOpticalSgNodes()
+        {
+            string sysfs = Path.Combine(Path.GetTempPath(), "mpf-test-sysfs-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(sysfs);
+            try
+            {
+                // Optical drives report SCSI peripheral device type 5
+                WriteScsiGenericType(sysfs, "sg0", "5");   // optical, kept
+                WriteScsiGenericType(sysfs, "sg2", "5\n");  // optical (trailing newline), kept
+                WriteScsiGenericType(sysfs, "sg10", "5");  // optical (multi-digit), kept
+                WriteScsiGenericType(sysfs, "sg1", "0");   // direct-access disk, skipped
+                WriteScsiGenericType(sysfs, "sg3", "1");   // sequential tape, skipped
+                WriteScsiGenericType(sysfs, "sga", "5");   // name not all-digits, skipped
+                WriteScsiGenericType(sysfs, "sgX", "5");   // name not all-digits, skipped
+                Directory.CreateDirectory(Path.Combine(sysfs, "sg4")); // no device/type, skipped
+
+                var actual = Drive.EnumerateUnixOpticalGenericPaths("/dev", sysfs);
+
+                var actualNames = new List<string>();
+                foreach (var p in actual)
+                {
+                    actualNames.Add(Path.GetFileName(p));
+                }
+                actualNames.Sort(StringComparer.Ordinal);
+
+                Assert.Equal(new[] { "sg0", "sg10", "sg2" }, actualNames);
+                Assert.Contains(Path.Combine("/dev", "sg0"), actual);
+            }
+            finally
+            {
+                Directory.Delete(sysfs, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// Create a fake sysfs scsi_generic entry "<![CDATA[<root>/<name>/device/type]]>" with the given content.
+        /// </summary>
+        private static void WriteScsiGenericType(string root, string name, string type)
+        {
+            string deviceDir = Path.Combine(root, name, "device");
+            Directory.CreateDirectory(deviceDir);
+            File.WriteAllText(Path.Combine(deviceDir, "type"), type);
         }
 
         #endregion

--- a/MPF.Frontend.Test/DriveTests.cs
+++ b/MPF.Frontend.Test/DriveTests.cs
@@ -92,7 +92,9 @@ namespace MPF.Frontend.Test
 
                 var actualNames = new List<string>();
                 foreach (var p in actual)
+                {
                     actualNames.Add(Path.GetFileName(p));
+                }
                 actualNames.Sort(StringComparer.Ordinal);
 
                 Assert.Equal(new[] { "sr0", "sr1", "sr15" }, actualNames);

--- a/MPF.Frontend/Drive.cs
+++ b/MPF.Frontend/Drive.cs
@@ -357,10 +357,12 @@ namespace MPF.Frontend
         }
 
         /// <summary>
-        /// Append Linux optical block devices (/dev/sr*) that DriveInfo did not surface.
+        /// Append Linux optical devices that DriveInfo did not surface.
         /// DriveInfo.GetDrives() returns mount points and typically does not list unmounted
         /// optical drives, so they are enumerated directly to let users dump discs without
-        /// mounting them first.
+        /// mounting them first. Both the block nodes (/dev/sr*) and their generic SCSI
+        /// counterparts (/dev/sg*) are surfaced, block nodes first, because dumping back ends
+        /// differ in which node they expect (e.g. redumper opens the generic node).
         /// </summary>
         /// <param name="drives">Drives already discovered via DriveInfo</param>
         /// <returns>The drive array, extended with any optical devices not already present</returns>
@@ -373,10 +375,16 @@ namespace MPF.Frontend
                     existingNames.Add(d.Name);
             }
 
+            // Block nodes first, then their generic SCSI counterparts
+            var devicePaths = new List<string>();
+            devicePaths.AddRange(EnumerateUnixOpticalBlockPaths("/dev"));
+            devicePaths.AddRange(EnumerateUnixOpticalGenericPaths("/dev", "/sys/class/scsi_generic"));
+
             var extra = new List<Drive>();
-            foreach (var devicePath in EnumerateUnixOpticalDevicePaths("/dev"))
+            foreach (var devicePath in devicePaths)
             {
-                if (existingNames.Contains(devicePath))
+                // Skip paths already surfaced by DriveInfo or an earlier enumerator
+                if (!existingNames.Add(devicePath))
                     continue;
 
                 try
@@ -406,7 +414,7 @@ namespace MPF.Frontend
         /// </summary>
         /// <param name="devRoot">Root directory to scan (typically "/dev")</param>
         /// <returns>Device paths, or an empty list when the directory is unreadable</returns>
-        internal static List<string> EnumerateUnixOpticalDevicePaths(string devRoot)
+        internal static List<string> EnumerateUnixOpticalBlockPaths(string devRoot)
         {
             var result = new List<string>();
             if (string.IsNullOrEmpty(devRoot) || !Directory.Exists(devRoot))
@@ -424,25 +432,84 @@ namespace MPF.Frontend
 
             foreach (var path in candidates)
             {
-                string name = Path.GetFileName(path);
-                if (name.Length < 3)
-                    continue;
-
-                bool allDigits = true;
-                for (int i = 2; i < name.Length; i++)
-                {
-                    if (!char.IsDigit(name[i]))
-                    {
-                        allDigits = false;
-                        break;
-                    }
-                }
-
-                if (allDigits)
+                if (HasDeviceIndexSuffix(Path.GetFileName(path), "sr"))
                     result.Add(path);
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Enumerate Linux optical drives via their generic SCSI nodes (/dev/sg*).
+        /// Unlike the block nodes, "sg" is not optical-specific, so each candidate is
+        /// confirmed against sysfs: an optical drive reports SCSI peripheral device type 5.
+        /// </summary>
+        /// <param name="devRoot">Root directory the nodes live under (typically "/dev")</param>
+        /// <param name="sysfsScsiGenericRoot">sysfs class directory (typically "/sys/class/scsi_generic")</param>
+        /// <returns>Device paths, or an empty list when the sysfs directory is unreadable</returns>
+        internal static List<string> EnumerateUnixOpticalGenericPaths(string devRoot, string sysfsScsiGenericRoot)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrEmpty(devRoot) || string.IsNullOrEmpty(sysfsScsiGenericRoot))
+                return result;
+            if (!Directory.Exists(sysfsScsiGenericRoot))
+                return result;
+
+            string[] entries;
+            try
+            {
+                entries = Directory.GetFileSystemEntries(sysfsScsiGenericRoot, "sg*");
+            }
+            catch
+            {
+                return result;
+            }
+
+            foreach (var entry in entries)
+            {
+                string name = Path.GetFileName(entry);
+                if (!HasDeviceIndexSuffix(name, "sg"))
+                    continue;
+
+                // "sg" is generic SCSI; keep only optical drives (peripheral device type 5)
+                string typePath = Path.Combine(Path.Combine(entry, "device"), "type");
+                try
+                {
+                    if (!File.Exists(typePath))
+                        continue;
+                    if (!int.TryParse(File.ReadAllText(typePath).Trim(), out int scsiType) || scsiType != 5)
+                        continue;
+                }
+                catch
+                {
+                    continue;
+                }
+
+                result.Add(Path.Combine(devRoot, name));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Check that a device node name is the given prefix followed by one or more digits
+        /// (e.g. "sr0", "sg12"), rejecting names with trailing or embedded non-digit characters.
+        /// </summary>
+        /// <param name="name">Device node name to check</param>
+        /// <param name="prefix">Required leading text (e.g. "sr", "sg")</param>
+        /// <returns>True when the name is the prefix followed only by digits</returns>
+        private static bool HasDeviceIndexSuffix(string name, string prefix)
+        {
+            if (name.Length <= prefix.Length || !name.StartsWith(prefix, StringComparison.Ordinal))
+                return false;
+
+            for (int i = prefix.Length; i < name.Length; i++)
+            {
+                if (!char.IsDigit(name[i]))
+                    return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/MPF.Frontend/Drive.cs
+++ b/MPF.Frontend/Drive.cs
@@ -313,7 +313,21 @@ namespace MPF.Frontend
                 return [.. drives];
             }
 
-            // Find and update all floppy drives
+            // Apply OS-specific drive adjustments
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                MarkWindowsFloppyDrives(drives);
+            else if (Environment.OSVersion.Platform == PlatformID.Unix)
+                drives = AppendUnixOpticalDrives(drives);
+
+            return [.. drives];
+        }
+
+        /// <summary>
+        /// Mark drives that Windows reports as floppy media via WMI.
+        /// </summary>
+        /// <param name="drives">Drives to update in place</param>
+        private static void MarkWindowsFloppyDrives(Drive[] drives)
+        {
 #if NET462_OR_GREATER || NETCOREAPP
             try
             {
@@ -340,49 +354,50 @@ namespace MPF.Frontend
                 // No-op
             }
 #endif
+        }
 
-            // On Linux, DriveInfo.GetDrives() returns mount points and typically
-            // does not surface unmounted optical block devices (/dev/sr*). Enumerate
-            // them directly so users can dump discs without first mounting them.
-            if (Environment.OSVersion.Platform == PlatformID.Unix)
+        /// <summary>
+        /// Append Linux optical block devices (/dev/sr*) that DriveInfo did not surface.
+        /// DriveInfo.GetDrives() returns mount points and typically does not list unmounted
+        /// optical drives, so they are enumerated directly to let users dump discs without
+        /// mounting them first.
+        /// </summary>
+        /// <param name="drives">Drives already discovered via DriveInfo</param>
+        /// <returns>The drive array, extended with any optical devices not already present</returns>
+        private static Drive[] AppendUnixOpticalDrives(Drive[] drives)
+        {
+            var existingNames = new HashSet<string>();
+            foreach (var d in drives)
             {
-                var existingNames = new HashSet<string>();
-                foreach (var d in drives)
+                if (d?.Name is not null)
+                    existingNames.Add(d.Name);
+            }
+
+            var extra = new List<Drive>();
+            foreach (var devicePath in EnumerateUnixOpticalDevicePaths("/dev"))
+            {
+                if (existingNames.Contains(devicePath))
+                    continue;
+
+                try
                 {
-                    if (d?.Name is not null)
-                        existingNames.Add(d.Name);
-                }
-
-                var extra = new List<Drive>();
-                foreach (var devicePath in EnumerateUnixOpticalDevicePaths("/dev"))
-                {
-                    if (existingNames.Contains(devicePath))
-                        continue;
-
-                    Drive? d;
-                    try
-                    {
-                        d = Create(Frontend.InternalDriveType.Optical, devicePath);
-                    }
-                    catch
-                    {
-                        d = null;
-                    }
-
+                    var d = Create(Frontend.InternalDriveType.Optical, devicePath);
                     if (d != null)
                         extra.Add(d);
                 }
-
-                if (extra.Count > 0)
+                catch
                 {
-                    var combined = new Drive[drives.Length + extra.Count];
-                    Array.Copy(drives, combined, drives.Length);
-                    extra.CopyTo(combined, drives.Length);
-                    drives = combined;
+                    // Skip devices that can't be opened
                 }
             }
 
-            return [.. drives];
+            if (extra.Count == 0)
+                return drives;
+
+            var combined = new Drive[drives.Length + extra.Count];
+            Array.Copy(drives, combined, drives.Length);
+            extra.CopyTo(combined, drives.Length);
+            return combined;
         }
 
         /// <summary>

--- a/MPF.Frontend/Drive.cs
+++ b/MPF.Frontend/Drive.cs
@@ -341,7 +341,93 @@ namespace MPF.Frontend
             }
 #endif
 
+            // On Linux, DriveInfo.GetDrives() returns mount points and typically
+            // does not surface unmounted optical block devices (/dev/sr*). Enumerate
+            // them directly so users can dump discs without first mounting them.
+            if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                var existingNames = new HashSet<string>();
+                foreach (var d in drives)
+                {
+                    if (d?.Name is not null)
+                        existingNames.Add(d.Name);
+                }
+
+                var extra = new List<Drive>();
+                foreach (var devicePath in EnumerateUnixOpticalDevicePaths("/dev"))
+                {
+                    if (existingNames.Contains(devicePath))
+                        continue;
+
+                    Drive? d;
+                    try
+                    {
+                        d = Create(Frontend.InternalDriveType.Optical, devicePath);
+                    }
+                    catch
+                    {
+                        d = null;
+                    }
+
+                    if (d != null)
+                        extra.Add(d);
+                }
+
+                if (extra.Count > 0)
+                {
+                    var combined = new Drive[drives.Length + extra.Count];
+                    Array.Copy(drives, combined, drives.Length);
+                    extra.CopyTo(combined, drives.Length);
+                    drives = combined;
+                }
+            }
+
             return [.. drives];
+        }
+
+        /// <summary>
+        /// Enumerate Linux optical block devices under a directory by matching
+        /// the kernel convention "sr" followed by one or more digits (sr0, sr1, ...).
+        /// </summary>
+        /// <param name="devRoot">Root directory to scan (typically "/dev")</param>
+        /// <returns>Device paths, or an empty list when the directory is unreadable</returns>
+        internal static List<string> EnumerateUnixOpticalDevicePaths(string devRoot)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrEmpty(devRoot) || !Directory.Exists(devRoot))
+                return result;
+
+            string[] candidates;
+            try
+            {
+                candidates = Directory.GetFiles(devRoot, "sr*");
+            }
+            catch
+            {
+                return result;
+            }
+
+            foreach (var path in candidates)
+            {
+                string name = Path.GetFileName(path);
+                if (name.Length < 3)
+                    continue;
+
+                bool allDigits = true;
+                for (int i = 2; i < name.Length; i++)
+                {
+                    if (!char.IsDigit(name[i]))
+                    {
+                        allDigits = false;
+                        break;
+                    }
+                }
+
+                if (allDigits)
+                    result.Add(path);
+            }
+
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
On Linux, `DriveInfo.GetDrives()` does not surface unmounted optical block
devices, so optical drives are missing from the drive list unless a disc is
already mounted. This enumerates `/dev/sr*` directly so discs can be dumped
without mounting first.

### What this PR does
- After the existing `GetDriveList()` logic, on Unix, scans `/dev` for kernel
  optical device nodes (`sr` followed by digits: `sr0`, `sr1`, …) and adds any
  not already present as optical `Drive` entries.
- Adds `Drive.EnumerateUnixOpticalDevicePaths(string)` (the scan/match helper),
  covered by unit tests.

### What this PR doesn't do
- Does not change Windows or macOS enumeration. The branch is gated on
  `PlatformID.Unix`; macOS/BSD have no `/dev/sr*` nodes, so it is a no-op there.
- Does not wire the enumerated path into filesystem-based heuristics.
  `Drive.Name` is set to the device path (e.g. `/dev/sr0`), which is correct as
  the dumper argument but is not a mountable filesystem path, so volume-label /
  PS3-PS4-PS5 detection / protection scanning remain unaddressed for these
  entries. That is a larger change and intentionally out of scope here.
- No new dependencies.

### Tests
`MPF.Frontend.Test/DriveTests.cs` — 3 cases for the matcher: null/empty root,
missing directory, and that only `sr` + digits match (`sr0`, `sr1`, `sr15`)
while `src`, `srm`, `serial0`, `sr`, `sr0a` are excluded. The matcher runs
against a temp directory, so the test is platform-independent.

Built net20 → net10.0, all green; full MPF.Frontend.Test suite passes (505).

Relates to the existing `// TODO: Reduce reliance on DriveInfo` note in
`Drive.cs`. Happy to rebase or adjust scope.

Prepared with AI assistance (Claude Opus 4.8) and reviewed before submission.
