### PR TITLE
Mark Linux optical drives as active

### DIFF
--- a/MPF.Frontend/Drive.cs
+++ b/MPF.Frontend/Drive.cs
@@ -391,7 +391,14 @@ namespace MPF.Frontend
                 {
                     var d = Create(Frontend.InternalDriveType.Optical, devicePath);
                     if (d != null)
+                    {
+                        // A Linux optical /dev node is never a mount point, so DriveInfo always
+                        // reports it as not-ready. Mark it active so it matches how Windows
+                        // surfaces optical drives; whether a disc is actually loaded is left to
+                        // the dumping program rather than probing the device here.
+                        d.MarkedActive = true;
                         extra.Add(d);
+                    }
                 }
                 catch
                 {


### PR DESCRIPTION
Linux optical `/dev` nodes are never mount points, so `DriveInfo` always reports them as not-ready — they were enumerated but never marked active. This marks all `/dev/sr*` and `/dev/sg*` nodes active on enumeration, matching how Windows surfaces optical drives.

Per the discussion on this PR, this drops the `CDROM_DRIVE_STATUS` ioctl approach in favor of always-active to avoid extra system calls. Whether a disc is actually loaded is left to the dumping program. Rebased onto current master, so the change is a small addition in `AppendUnixOpticalDrives`.

*Prepared with AI assistance (Claude Opus 4.8) and reviewed before submission.*
