### PR TITLE
Update Redumper to build 726

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -51,6 +51,7 @@
 - Fix supported region list
 - Fix some lingering naming issues
 - Remove PS5 hack
+- Update Redumper to build 726
 
 ### 3.7.1 (2026-03-30)
 

--- a/MPF.ExecutionContexts/Redumper/CommandStrings.cs
+++ b/MPF.ExecutionContexts/Redumper/CommandStrings.cs
@@ -20,6 +20,7 @@ namespace MPF.ExecutionContexts.Redumper
         public const string Info = "info";
         public const string Skeleton = "skeleton";
         public const string FlashMT1339 = "flash::mt1339";
+        public const string FlashMT1959 = "flash::mt1959";
         public const string FlashSD616 = "flash::sd616";
         public const string FlashPlextor = "flash::plextor";
         public const string Subchannel = "subchannel";

--- a/MPF.ExecutionContexts/Redumper/ExecutionContext.cs
+++ b/MPF.ExecutionContexts/Redumper/ExecutionContext.cs
@@ -472,6 +472,7 @@ namespace MPF.ExecutionContexts.Redumper
                     case CommandStrings.Info:
                     case CommandStrings.Skeleton:
                     case CommandStrings.FlashMT1339:
+                    case CommandStrings.FlashMT1959:
                     case CommandStrings.FlashSD616:
                     case CommandStrings.FlashPlextor:
                     case CommandStrings.Subchannel:

--- a/MPF.Processors.Test/TestData/Redumper/CDROM/test.log
+++ b/MPF.Processors.Test/TestData/Redumper/CDROM/test.log
@@ -27,10 +27,10 @@ copyright:
 
 << GetErrorCount >>
 C2: 12345
-REDUMP.ORG errors: 12345
+REDUMP.INFO errors: 12345
 
 C2: 1
-REDUMP.ORG errors: 2
+REDUMP.INFO errors: 2
 
 C2: 12 samples
 

--- a/MPF.Processors/Redumper.cs
+++ b/MPF.Processors/Redumper.cs
@@ -1465,8 +1465,8 @@ namespace MPF.Processors
                         }
                     }
 
-                    // REDUMP.ORG errors: <error count>
-                    else if (line.StartsWith("REDUMP.ORG errors:"))
+                    // REDUMP.INFO errors: <error count>
+                    else if (line.StartsWith("REDUMP.INFO errors:"))
                     {
                         // Ensure there are the correct number of parts
                         string[] parts = line!.Split(' ');
@@ -2953,6 +2953,25 @@ namespace MPF.Processors
                     else if (line.StartsWith("HFS ["))
                     {
                         currentFilesystem = "HFS";
+                    }
+
+                    // Joliet Volume Identifier
+                    else if (line.StartsWith("joliet volume identifier: "))
+                    {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                        string label = line["joliet volume identifier: ".Length..];
+#else
+                        string label = line.Substring("joliet volume identifier: ".Length);
+#endif
+
+                        // Skip if label is blank
+                        if (label is null || label.Length <= 0)
+                            break;
+
+                        if (volLabels.TryGetValue(label, out List<string>? value))
+                            value.Add("Joliet");
+                        else
+                            volLabels[label] = ["Joliet"];
                     }
 
                     // ISO9660 and HFS Volume Identifier

--- a/publish-nix.sh
+++ b/publish-nix.sh
@@ -103,14 +103,14 @@ function download_programs() {
     DL_MAP["Creator_win-x86"]="https://github.com/user-attachments/files/24401506/DiscImageCreator_20260101.zip"
 
     # Redumper
-    DL_MAP["Redumper_linux-arm64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-arm64.zip"
-    DL_MAP["Redumper_linux-x64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-x64.zip"
-    #DL_MAP["Redumper_linux_x86"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-x86.zip"
-    DL_MAP["Redumper_osx-arm64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-macos-arm64.zip"
-    DL_MAP["Redumper_osx-x64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-macos-x64.zip"
-    DL_MAP["Redumper_win-arm64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-windows-arm64.zip"
+    DL_MAP["Redumper_linux-arm64"]="https://github.com/superg/redumper/releases/download/b726/redumper-b726-linux-arm64.zip"
+    DL_MAP["Redumper_linux-x64"]="https://github.com/superg/redumper/releases/download/b726/redumper-b726-linux-x64.zip"
+    #DL_MAP["Redumper_linux_x86"]="https://github.com/superg/redumper/releases/download/b726/redumper-b726-linux-x86.zip"
+    DL_MAP["Redumper_osx-arm64"]="https://github.com/superg/redumper/releases/download/b726/redumper-b726-macos-arm64.zip"
+    DL_MAP["Redumper_osx-x64"]="https://github.com/superg/redumper/releases/download/b726/redumper-b726-macos-x64.zip"
+    DL_MAP["Redumper_win-arm64"]="https://github.com/superg/redumper/releases/download/b726/redumper-b726-windows-arm64.zip"
     DL_MAP["Redumper_win-x64"]="https://github.com/superg/redumper/releases/download/b726/redumper-b726-windows-x64.zip"
-    DL_MAP["Redumper_win-x86"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-windows-x86.zip"
+    DL_MAP["Redumper_win-x86"]="https://github.com/superg/redumper/releases/download/b726/redumper-b726-windows-x86.zip"
 
     # Download and extract files
     echo "===== Downloading Required Programs ====="

--- a/publish-nix.sh
+++ b/publish-nix.sh
@@ -103,14 +103,14 @@ function download_programs() {
     DL_MAP["Creator_win-x86"]="https://github.com/user-attachments/files/24401506/DiscImageCreator_20260101.zip"
 
     # Redumper
-    DL_MAP["Redumper_linux-arm64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b706-linux-arm64.zip"
-    DL_MAP["Redumper_linux-x64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b706-linux-x64.zip"
-    #DL_MAP["Redumper_linux_x86"]="https://github.com/superg/redumper/releases/download/b706/redumper-b706-linux-x86.zip"
-    DL_MAP["Redumper_osx-arm64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b706-macos-arm64.zip"
-    DL_MAP["Redumper_osx-x64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b706-macos-x64.zip"
-    DL_MAP["Redumper_win-arm64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b706-windows-arm64.zip"
-    DL_MAP["Redumper_win-x64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b706-windows-x64.zip"
-    DL_MAP["Redumper_win-x86"]="https://github.com/superg/redumper/releases/download/b706/redumper-b706-windows-x86.zip"
+    DL_MAP["Redumper_linux-arm64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-arm64.zip"
+    DL_MAP["Redumper_linux-x64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-x64.zip"
+    #DL_MAP["Redumper_linux_x86"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-x86.zip"
+    DL_MAP["Redumper_osx-arm64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-macos-arm64.zip"
+    DL_MAP["Redumper_osx-x64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-macos-x64.zip"
+    DL_MAP["Redumper_win-arm64"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-windows-arm64.zip"
+    DL_MAP["Redumper_win-x64"]="https://github.com/superg/redumper/releases/download/b726/redumper-b726-windows-x64.zip"
+    DL_MAP["Redumper_win-x86"]="https://github.com/superg/redumper/releases/download/b706/redumper-b726-windows-x86.zip"
 
     # Download and extract files
     echo "===== Downloading Required Programs ====="

--- a/publish-win.ps1
+++ b/publish-win.ps1
@@ -92,14 +92,14 @@ function Download-Programs {
         "Creator_win-x64"      = "https://github.com/user-attachments/files/24401506/DiscImageCreator_20260101.zip"
 
         # Redumper
-        "Redumper_linux-arm64" = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-arm64.zip"
-        "Redumper_linux-x64"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-x64.zip"
-        #"Redumper_linux-x86"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-x86.zip"
-        "Redumper_osx-arm64"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-macos-arm64.zip"
-        "Redumper_osx-x64"     = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-macos-x64.zip"
-        "Redumper_win-arm64"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-windows-arm64.zip"
-        "Redumper_win-x86"     = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-windows-x86.zip"
-        "Redumper_win-x64"     = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-windows-x64.zip"
+        "Redumper_linux-arm64" = "https://github.com/superg/redumper/releases/download/b726/redumper-b726-linux-arm64.zip"
+        "Redumper_linux-x64"   = "https://github.com/superg/redumper/releases/download/b726/redumper-b726-linux-x64.zip"
+        #"Redumper_linux-x86"   = "https://github.com/superg/redumper/releases/download/b726/redumper-b726-linux-x86.zip"
+        "Redumper_osx-arm64"   = "https://github.com/superg/redumper/releases/download/b726/redumper-b726-macos-arm64.zip"
+        "Redumper_osx-x64"     = "https://github.com/superg/redumper/releases/download/b726/redumper-b726-macos-x64.zip"
+        "Redumper_win-arm64"   = "https://github.com/superg/redumper/releases/download/b726/redumper-b726-windows-arm64.zip"
+        "Redumper_win-x86"     = "https://github.com/superg/redumper/releases/download/b726/redumper-b726-windows-x86.zip"
+        "Redumper_win-x64"     = "https://github.com/superg/redumper/releases/download/b726/redumper-b726-windows-x64.zip"
     }
 
     # Download and extract files

--- a/publish-win.ps1
+++ b/publish-win.ps1
@@ -92,14 +92,14 @@ function Download-Programs {
         "Creator_win-x64"      = "https://github.com/user-attachments/files/24401506/DiscImageCreator_20260101.zip"
 
         # Redumper
-        "Redumper_linux-arm64" = "https://github.com/superg/redumper/releases/download/b706/redumper-b706-linux-arm64.zip"
-        "Redumper_linux-x64"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b706-linux-x64.zip"
-        #"Redumper_linux-x86"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b706-linux-x86.zip"
-        "Redumper_osx-arm64"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b706-macos-arm64.zip"
-        "Redumper_osx-x64"     = "https://github.com/superg/redumper/releases/download/b706/redumper-b706-macos-x64.zip"
-        "Redumper_win-arm64"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b706-windows-arm64.zip"
-        "Redumper_win-x86"     = "https://github.com/superg/redumper/releases/download/b706/redumper-b706-windows-x86.zip"
-        "Redumper_win-x64"     = "https://github.com/superg/redumper/releases/download/b706/redumper-b706-windows-x64.zip"
+        "Redumper_linux-arm64" = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-arm64.zip"
+        "Redumper_linux-x64"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-x64.zip"
+        #"Redumper_linux-x86"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-linux-x86.zip"
+        "Redumper_osx-arm64"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-macos-arm64.zip"
+        "Redumper_osx-x64"     = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-macos-x64.zip"
+        "Redumper_win-arm64"   = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-windows-arm64.zip"
+        "Redumper_win-x86"     = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-windows-x86.zip"
+        "Redumper_win-x64"     = "https://github.com/superg/redumper/releases/download/b706/redumper-b726-windows-x64.zip"
     }
 
     # Download and extract files


### PR DESCRIPTION
Changes:
- Update Redumper to b726
- New flash::mt1959 command
- REDUMP.ORG errors is now REDUMP.INFO errors
- Parse Joliet volume identifier from log

TODO (not in this PR): These already happen in PhysicalTool but parsing from redumper should be preferred (and also will work for Check):
- Parse PS3 Firmware update version from redumper log and format to standard redump format. 
- Prepare for PS4/PS5 package ID parsing in future builds: https://github.com/superg/redumper/pull/390

Fixes #976 