### PR TITLE
Add live tool output console for the Linux GUI

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,3 +1,7 @@
+### WIP (xxxx-xx-xx)
+
+- Add live tool output console for the Linux GUI (gmipf)
+
 ### 3.8.2 (2026-07-01)
 
 - Output used configuration path for commandline programs

--- a/MPF.Avalonia/Helpers/OutputPump.cs
+++ b/MPF.Avalonia/Helpers/OutputPump.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace MPF.Avalonia.Helpers
+{
+    /// <summary>
+    /// Decouples the process-output producer from the (slow) UI consumer with a
+    /// bounded channel, so a firehose of output can never block the reader thread
+    /// or grow memory without bound -- the two failure modes behind the old lag.
+    ///
+    /// - Producer side (<see cref="Post"/>) is called from the stdout/stderr read
+    ///   loops. It never blocks: when the consumer falls behind and the buffer is
+    ///   full, the OLDEST queued chunk is dropped (<see cref="BoundedChannelFullMode.DropOldest"/>).
+    ///   The raw stream is still written to the log file in full elsewhere, so
+    ///   dropping only affects the live on-screen tail, never the saved log.
+    /// - Consumer side drains everything currently available in ONE batch
+    ///   (<see cref="DrainAvailable"/>), so the UI does a single dispatch per
+    ///   flush tick instead of one per line. That is what keeps a high output
+    ///   rate from saturating the UI thread.
+    /// </summary>
+    public sealed class OutputPump
+    {
+        private readonly Channel<string> _channel;
+
+        public OutputPump(int capacity = 8192)
+        {
+            _channel = Channel.CreateBounded<string>(new BoundedChannelOptions(capacity)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                SingleReader = true,
+                SingleWriter = false,
+            });
+        }
+
+        /// <summary>
+        /// Producer: enqueue a raw output chunk. Never blocks, never throws on full.
+        /// </summary>
+        public void Post(string chunk)
+        {
+            // With DropOldest, TryWrite always succeeds for a bounded channel and
+            // silently evicts the oldest item when full -- exactly the backpressure
+            // we want for a live tail. After completion TryWrite returns false, which
+            // we ignore (output arriving after the window closed is simply dropped).
+            _channel.Writer.TryWrite(chunk);
+        }
+
+        /// <summary>
+        /// Signal that no more output will arrive.
+        /// </summary>
+        public void Complete() => _channel.Writer.TryComplete();
+
+        /// <summary>
+        /// Drain every chunk currently queued into one list, without waiting.
+        /// Caller feeds the batch to a <see cref="TerminalBuffer"/> and pushes a
+        /// single UI update. <paramref name="max"/> caps a single drain so one
+        /// pathological burst cannot monopolize a flush tick.
+        /// </summary>
+        public List<string> DrainAvailable(int max = 4096)
+        {
+            var batch = new List<string>();
+            while (batch.Count < max && _channel.Reader.TryRead(out string? chunk))
+            {
+                batch.Add(chunk);
+            }
+
+            return batch;
+        }
+
+        /// <summary>
+        /// Await at least one chunk being available (or completion). For the flush loop.
+        /// </summary>
+        public ValueTask<bool> WaitToReadAsync(CancellationToken ct = default)
+            => _channel.Reader.WaitToReadAsync(ct);
+
+        /// <summary>
+        /// Reference flush loop: wait, drain a batch, feed the buffer, raise one
+        /// onBatch callback (with the number of chunks consumed in the batch), then
+        /// throttle. In the GUI this callback marshals to the UI thread once per
+        /// batch. Throttling is what bounds the dispatch rate.
+        /// </summary>
+        public async Task RunAsync(TerminalBuffer buffer, Action<int> onBatch, int flushIntervalMs = 75, CancellationToken ct = default)
+        {
+            try
+            {
+                while (await WaitToReadAsync(ct).ConfigureAwait(false))
+                {
+                    List<string> batch = DrainAvailable();
+                    if (batch.Count > 0)
+                    {
+                        foreach (string chunk in batch)
+                        {
+                            buffer.Feed(chunk);
+                        }
+
+                        onBatch(batch.Count);
+                    }
+
+                    if (flushIntervalMs > 0)
+                        await Task.Delay(flushIntervalMs, ct).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // expected on shutdown
+            }
+
+            // Final drain after completion so the tail is not lost.
+            List<string> tail = DrainAvailable();
+            foreach (string chunk in tail)
+            {
+                buffer.Feed(chunk);
+            }
+
+            buffer.Flush();
+            onBatch(tail.Count);
+        }
+    }
+}

--- a/MPF.Avalonia/Helpers/TerminalBuffer.cs
+++ b/MPF.Avalonia/Helpers/TerminalBuffer.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MPF.Avalonia.Helpers
+{
+    /// <summary>
+    /// Minimal terminal line-discipline for redirected child-process output.
+    ///
+    /// The point: read RAW characters from stdout (never <c>ReadLine</c>) and
+    /// interpret carriage returns the way a real terminal does. Dump tools
+    /// (redumper, DiscImageCreator, Aaru) update their progress with a bare
+    /// <c>\r</c> (no <c>\n</c>) so the same physical line is redrawn in place.
+    /// <c>ReadLine</c>/<c>OutputDataReceived</c> treat <c>\r</c> as a line break,
+    /// which explodes one updating line into thousands of separate lines -- the
+    /// spam + lag the maintainer saw when output was redirected years ago.
+    ///
+    /// Here, <c>\r</c> moves the write cursor to column 0 of the live line
+    /// (overwrite, not new line); <c>\n</c> commits the live line. Progress
+    /// updates therefore mutate a single live line and never grow the log.
+    ///
+    /// No UI dependency: pure and unit-testable. The UI binds the committed lines
+    /// to a virtualized list and the live line to one trailing row.
+    /// </summary>
+    public sealed class TerminalBuffer
+    {
+        private readonly StringBuilder _current = new();
+
+        /// <summary>
+        /// Write column within <see cref="_current"/>
+        /// </summary>
+        private int _cursor;
+
+        /// <summary>
+        /// Mid ANSI escape sequence (survives chunk boundaries)
+        /// </summary>
+        private bool _inEscape;
+
+        private readonly StringBuilder _escape = new();
+
+        /// <summary>
+        /// Lines committed so far (each was terminated by <c>\n</c>).
+        /// </summary>
+        public List<string> CommittedLines { get; } = new();
+
+        /// <summary>
+        /// The live line being assembled after the last <c>\n</c>.
+        /// </summary>
+        public string CurrentLine => _current.ToString();
+
+        /// <summary>
+        /// Raised once per committed line.
+        /// </summary>
+        public event Action<string>? LineCommitted;
+
+        /// <summary>
+        /// Raised when the live line changes (printable char, <c>\r</c> overwrite, erase).
+        /// </summary>
+        public event Action<string>? CurrentLineChanged;
+
+        /// <summary>
+        /// Feed a raw chunk of output. Chunk boundaries are arbitrary: a <c>\r\n</c>
+        /// or an escape sequence may be split across two calls and is handled.
+        /// </summary>
+        public void Feed(string? chunk)
+        {
+            if (string.IsNullOrEmpty(chunk))
+                return;
+
+            bool liveChanged = false;
+            for (int i = 0; i < chunk.Length; i++)
+            {
+                char c = chunk[i];
+
+                if (_inEscape)
+                {
+                    liveChanged |= FeedEscape(c);
+                    continue;
+                }
+
+                switch (c)
+                {
+                    case '\x1b': // ESC -- start of an ANSI sequence
+                        _inEscape = true;
+                        _escape.Clear();
+                        break;
+
+                    case '\n':
+                        CommitLine();
+                        break;
+
+                    case '\r':
+                        _cursor = 0; // carriage return: back to column 0, keep the chars
+                        break;
+
+                    case '\t':
+                        do { WriteChar(' '); } while (_cursor % 8 != 0);
+                        liveChanged = true;
+                        break;
+
+                    case '\b':
+                        if (_cursor > 0)
+                            _cursor--;
+
+                        break;
+
+                    default:
+                        if (!char.IsControl(c))
+                        {
+                            WriteChar(c);
+                            liveChanged = true;
+                        }
+                        // other control chars (bell, etc.) are dropped
+                        break;
+                }
+            }
+
+            if (liveChanged)
+                CurrentLineChanged?.Invoke(CurrentLine);
+        }
+
+        /// <summary>
+        /// Force-commit whatever is in the live line (e.g. on process exit).
+        /// </summary>
+        public void Flush()
+        {
+            if (_current.Length > 0)
+                CommitLine();
+        }
+
+        private void WriteChar(char c)
+        {
+            if (_cursor < _current.Length)
+                _current[_cursor] = c;
+            else
+                _current.Append(c);
+
+            _cursor++;
+        }
+
+        private void CommitLine()
+        {
+            string line = _current.ToString();
+            CommittedLines.Add(line);
+            LineCommitted?.Invoke(line);
+            _current.Clear();
+            _cursor = 0;
+        }
+
+        /// <summary>
+        /// Consume one character of an in-progress escape sequence. We only model
+        /// the few CSI sequences progress writers actually use; everything else
+        /// (colors, cursor moves) is recognized and stripped so it never shows as
+        /// literal garbage. Returns whether the live line changed.
+        /// </summary>
+        private bool FeedEscape(char c)
+        {
+            // First char after ESC decides the family.
+            if (_escape.Length == 0)
+            {
+                if (c == '[')
+                {
+                    _escape.Append(c); // CSI -- keep collecting until a final byte
+                    return false;
+                }
+
+                // Not a CSI (e.g. ESC( charset, ESC] OSC). We don't model these;
+                // drop ESC + this byte and resume. Good enough for tool output.
+                _inEscape = false;
+                return false;
+            }
+
+            // Inside CSI: parameters/intermediates until a final byte 0x40-0x7E.
+            if (c >= '@' && c <= '~')
+            {
+                bool changed = ApplyCsi(_escape.ToString(1, _escape.Length - 1), c);
+                _inEscape = false;
+                _escape.Clear();
+                return changed;
+            }
+
+            _escape.Append(c);
+            return false;
+        }
+
+        /// <summary>
+        /// Apply a CSI sequence given its parameter string and final byte.
+        /// </summary>
+        private bool ApplyCsi(string parameters, char final)
+        {
+            switch (final)
+            {
+                case 'K': // EL -- erase in line
+                    EraseInLine(ParseInt(parameters, 0));
+                    return true;
+
+                case 'G': // CHA -- cursor to absolute column (1-based)
+                    _cursor = Math.Max(0, ParseInt(parameters, 1) - 1);
+                    return false;
+
+                case 'D': // CUB -- cursor back N
+                    _cursor = Math.Max(0, _cursor - Math.Max(1, ParseInt(parameters, 1)));
+                    return false;
+
+                default:
+                    // SGR colors ('m'), cursor up/down, etc. -- recognized and ignored.
+                    return false;
+            }
+        }
+
+        private void EraseInLine(int mode)
+        {
+            switch (mode)
+            {
+                case 0: // cursor to end of line
+                    if (_cursor < _current.Length)
+                        _current.Length = _cursor;
+
+                    break;
+                case 1: // start of line to cursor (blank them, keep length)
+                    for (int i = 0; i < _cursor && i < _current.Length; i++)
+                    {
+                        _current[i] = ' ';
+                    }
+
+                    break;
+                case 2: // entire line
+                    _current.Clear();
+                    _cursor = 0;
+                    break;
+            }
+        }
+
+        private static int ParseInt(string s, int fallback)
+            => int.TryParse(s, out int v) ? v : fallback;
+    }
+}

--- a/MPF.Avalonia/Resources/Strings.de.xaml
+++ b/MPF.Avalonia/Resources/Strings.de.xaml
@@ -10,6 +10,8 @@
     <x:String x:Key="CancelButtonString">Abbrechen</x:String>
     <x:String x:Key="MinimizeMenuItemString">Minimieren</x:String>
     <x:String x:Key="CloseMenuItemString">Schließen</x:String>
+    <x:String x:Key="CopyMenuItemString">Kopieren</x:String>
+    <x:String x:Key="SelectAllMenuItemString">Alles auswählen</x:String>
     <x:String x:Key="SettingsGroupBoxString">Einstellungen</x:String>
     <x:String x:Key="StatusGroupBoxString">Status</x:String>
     <x:String x:Key="WarningLabelString">WARNUNG:</x:String>
@@ -48,6 +50,10 @@
     <x:String x:Key="LogOutputExpanderString">Protokollausgabe</x:String>
     <x:String x:Key="ClearButtonString">Löschen</x:String>
     <x:String x:Key="SaveButtonString">Speichern</x:String>
+
+    <!-- Tool Output Window -->
+    <x:String x:Key="ToolOutputTitleString">Programmausgabe</x:String>
+    <x:String x:Key="ToolOutputCloseOnExitCheckBoxString">Dieses Fenster schließen, wenn das Programm beendet ist</x:String>
 
     <!-- Options Window -->
     <x:String x:Key="OptionsTitleString">Optionen</x:String>

--- a/MPF.Avalonia/Resources/Strings.xaml
+++ b/MPF.Avalonia/Resources/Strings.xaml
@@ -10,6 +10,8 @@
     <x:String x:Key="CancelButtonString">Cancel</x:String>
     <x:String x:Key="MinimizeMenuItemString">Minimize</x:String>
     <x:String x:Key="CloseMenuItemString">Close</x:String>
+    <x:String x:Key="CopyMenuItemString">Copy</x:String>
+    <x:String x:Key="SelectAllMenuItemString">Select All</x:String>
     <x:String x:Key="SettingsGroupBoxString">Settings</x:String>
     <x:String x:Key="StatusGroupBoxString">Status</x:String>
     <x:String x:Key="WarningLabelString">WARNING:</x:String>
@@ -49,6 +51,10 @@
     <x:String x:Key="LogOutputExpanderString">Log Output</x:String>
     <x:String x:Key="ClearButtonString">Clear Log</x:String>
     <x:String x:Key="SaveButtonString">Save Log</x:String>
+
+    <!-- Tool Output Window -->
+    <x:String x:Key="ToolOutputTitleString">Program Output</x:String>
+    <x:String x:Key="ToolOutputCloseOnExitCheckBoxString">Close this window when the program exits</x:String>
 
     <!-- Options Window -->
     <x:String x:Key="OptionsTitleString">Options</x:String>

--- a/MPF.Avalonia/Services/ToolOutputConsole.cs
+++ b/MPF.Avalonia/Services/ToolOutputConsole.cs
@@ -1,0 +1,128 @@
+using System;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Platform;
+using MPF.Avalonia.Windows;
+using MPF.Frontend;
+using MPF.Frontend.Tools;
+
+namespace MPF.Avalonia.Services
+{
+    /// <summary>
+    /// Bridges the frontend's <see cref="IToolOutputConsole"/> seam to an Avalonia
+    /// <see cref="ToolOutputWindow"/>.
+    /// </summary>
+    /// <remarks>
+    /// Only created on platforms that need an in-app console for the dumping tool (Linux,
+    /// where the tool has no console window of its own). The window is shown modeless and
+    /// owned, so the MPF main window keeps working and its Stop button stays reachable.
+    /// </remarks>
+    public sealed class ToolOutputConsole : IToolOutputConsole
+    {
+        /// <summary>
+        /// Gap between the main window and the tool-output window, in device-independent pixels
+        /// </summary>
+        private const double PlacementGap = 8;
+
+        private readonly Window _owner;
+        private readonly Options _options;
+        private ToolOutputWindow? _window;
+
+        public ToolOutputConsole(Window owner, Options options)
+        {
+            _owner = owner;
+            _options = options;
+        }
+
+        /// <inheritdoc/>
+        public void Open()
+        {
+            // Discard any leftover console from a previous run (kept open because the user
+            // turned off auto-close) so each dump starts with a clean console.
+            _window?.Close();
+            _window = null;
+
+            var window = new ToolOutputWindow(_options.GUI.ToolConsoleAutoClose);
+            window.AutoCloseChanged += OnAutoCloseChanged;
+            window.Closed += (_, _) =>
+            {
+                if (ReferenceEquals(_window, window))
+                    _window = null;
+            };
+            _window = window;
+
+            TryPositionBesideOwner(window);
+            window.Show(_owner);
+        }
+
+        /// <inheritdoc/>
+        public void Append(string chunk) => _window?.Append(chunk);
+
+        /// <inheritdoc/>
+        public void NotifyToolExited() => _window?.NotifyToolExited();
+
+        /// <summary>
+        /// Persist the user's auto-close preference whenever the checkbox is toggled
+        /// </summary>
+        private void OnAutoCloseChanged(bool autoClose)
+        {
+            _options.GUI.ToolConsoleAutoClose = autoClose;
+            OptionsLoader.SaveToConfig(_options);
+        }
+
+        /// <summary>
+        /// Place the console beside the main window on whichever side has room, falling back
+        /// to overlaying the main window; always clamped fully inside the monitor work area.
+        /// </summary>
+        private void TryPositionBesideOwner(ToolOutputWindow window)
+        {
+            try
+            {
+                Screen? screen = _owner.Screens.ScreenFromWindow(_owner) ?? _owner.Screens.Primary;
+                if (screen is null)
+                {
+                    window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+                    return;
+                }
+
+                double scale = screen.Scaling;
+                PixelRect area = screen.WorkingArea;
+
+                // Owner frame and the new window, converted to physical pixels.
+                Size ownerSize = _owner.FrameSize ?? _owner.Bounds.Size;
+                PixelPoint ownerPos = _owner.Position;
+                int ownerW = (int)Math.Round(ownerSize.Width * scale);
+                int winW = (int)Math.Round(window.Width * scale);
+                int winH = (int)Math.Round(window.Height * scale);
+                int gap = (int)Math.Round(PlacementGap * scale);
+
+                int rightRoom = (area.X + area.Width) - (ownerPos.X + ownerW);
+                int leftRoom = ownerPos.X - area.X;
+
+                int x;
+                if (rightRoom >= winW + gap)
+                    x = ownerPos.X + ownerW + gap;              // beside, to the right
+                else if (leftRoom >= winW + gap)
+                    x = ownerPos.X - gap - winW;                // beside, to the left
+                else
+                    x = ownerPos.X + (ownerW - winW) / 2;       // overlay, centered on the owner
+
+                int y = ownerPos.Y;                             // align tops
+
+                // Clamp the whole window inside the work area so it never lands off-screen.
+                int maxX = (area.X + area.Width) - winW;
+                int maxY = (area.Y + area.Height) - winH;
+                x = Math.Max(area.X, Math.Min(x, maxX));
+                y = Math.Max(area.Y, Math.Min(y, maxY));
+
+                window.WindowStartupLocation = WindowStartupLocation.Manual;
+                window.Position = new PixelPoint(x, y);
+            }
+            catch
+            {
+                // Any platform quirk in the geometry math -> just center on the owner.
+                window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            }
+        }
+    }
+}

--- a/MPF.Avalonia/Windows/MainWindow.axaml.cs
+++ b/MPF.Avalonia/Windows/MainWindow.axaml.cs
@@ -116,10 +116,18 @@ namespace MPF.Avalonia.Windows
             if (MainViewModel.Options.GUI.ShowDebugViewMenuItem)
                 DebugViewMenuItem!.IsVisible = true;
 
+            // On Linux the dumping tool has no console window of its own, so stream its
+            // live output into a separate MPF window. Windows/macOS keep the tool's own
+            // console (leave this null), preserving the original behavior.
+            IToolOutputConsole? toolConsole = OperatingSystem.IsLinux()
+                ? new ToolOutputConsole(this, MainViewModel.Options)
+                : null;
+
             MainViewModel.Init(
                 LogOutput!.EnqueueLog,
                 DisplayUserMessage,
-                ShowMediaInformationWindow);
+                ShowMediaInformationWindow,
+                toolConsole);
 
             // Pass translation strings to MainViewModel
             var translationStrings = new Dictionary<string, string>

--- a/MPF.Avalonia/Windows/ToolOutputWindow.axaml
+++ b/MPF.Avalonia/Windows/ToolOutputWindow.axaml
@@ -1,0 +1,84 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="MPF.Avalonia.Windows.ToolOutputWindow"
+        Width="1040" Height="600"
+        MinWidth="480" MinHeight="240"
+        Title="{DynamicResource ToolOutputTitleString}">
+  <!-- Fixed default size. Width fits redumper's longest *regular* output line - the
+       drive "configuration:" line (~122 chars), which has no user-controllable parts
+       (no filenames or paths). 1040 covers it with margin; the genuinely unbounded
+       lines (dat <rom> filenames, output paths) are intentionally left to scroll
+       horizontally. Height is then chosen to keep a standard terminal's proportions:
+       KDE Konsole's default 80x24 grid at a typical monospace cell is ~1.73:1, so
+       1040 wide -> ~600 tall. The values are hard-coded literals; the ratio is just
+       the rationale, not computed at runtime. -->
+  <Grid RowDefinitions="*,Auto,Auto" Margin="8" RowSpacing="6">
+
+    <!-- Committed output. Virtualized, fixed-height rows; '\r' progress redraws
+         collapse onto the single live line below and never enter this list. -->
+    <Border Grid.Row="0" Background="#0F1115" CornerRadius="3">
+      <ListBox x:Name="LinesList"
+               Background="Transparent"
+               Padding="6,4"
+               SelectionMode="Multiple"
+               AutoScrollToSelectedItem="False"
+               ScrollViewer.HorizontalScrollBarVisibility="Auto"
+               ScrollViewer.VerticalScrollBarVisibility="Auto">
+        <ListBox.ContextMenu>
+          <ContextMenu>
+            <MenuItem x:Name="CopyMenuItem" Header="{DynamicResource CopyMenuItemString}" InputGesture="Ctrl+C" />
+            <MenuItem x:Name="SelectAllMenuItem" Header="{DynamicResource SelectAllMenuItemString}" InputGesture="Ctrl+A" />
+          </ContextMenu>
+        </ListBox.ContextMenu>
+        <ListBox.Styles>
+          <!-- Fixed row height -> exact virtualization extent -> the scrollbar
+               bottom does not jitter as rows realize/derealize. -->
+          <Style Selector="ListBoxItem">
+            <Setter Property="MinHeight" Value="0" />
+            <Setter Property="Height" Value="16" />
+            <Setter Property="Padding" Value="0" />
+            <!-- Non-focusable: a focused item raises RequestBringIntoView, which scrolls
+                 the row fully into view and kicks the content horizontally on selection.
+                 Shift/Ctrl-click multi-select does not need item focus, and Ctrl+C /
+                 Ctrl+A are handled at the window level, so keyboard still works. -->
+            <Setter Property="Focusable" Value="False" />
+          </Style>
+        </ListBox.Styles>
+        <ListBox.ItemsPanel>
+          <ItemsPanelTemplate>
+            <VirtualizingStackPanel />
+          </ItemsPanelTemplate>
+        </ListBox.ItemsPanel>
+        <ListBox.ItemTemplate>
+          <DataTemplate>
+            <TextBlock Text="{Binding}"
+                       Foreground="#D8DEE9"
+                       FontFamily="Consolas, Menlo, monospace"
+                       FontSize="12"
+                       LineHeight="15" />
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
+    </Border>
+
+    <!-- Live line: ONE row, redrawn in place by '\r' handling -->
+    <Border Grid.Row="1" Background="#08090C" CornerRadius="3" Padding="6,4">
+      <TextBlock x:Name="LiveLine"
+                 FontFamily="Consolas, Menlo, monospace"
+                 FontSize="12"
+                 Foreground="#A3BE8C"
+                 Text="" />
+    </Border>
+
+    <!-- Auto-close toggle. Checked (default) = close this window when the tool exits;
+         unchecked = keep it open to read the final output. The main MPF window keeps
+         working regardless. The state is persisted to the options. -->
+    <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="12"
+                Margin="2,2,2,0" VerticalAlignment="Center">
+      <CheckBox x:Name="AutoCloseCheck"
+                Content="{DynamicResource ToolOutputCloseOnExitCheckBoxString}"
+                IsChecked="True"
+                VerticalAlignment="Center" />
+    </StackPanel>
+  </Grid>
+</Window>

--- a/MPF.Avalonia/Windows/ToolOutputWindow.axaml.cs
+++ b/MPF.Avalonia/Windows/ToolOutputWindow.axaml.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using global::Avalonia.Controls;
+using global::Avalonia.Controls.Primitives;
+using global::Avalonia.Input;
+using global::Avalonia.Input.Platform;
+using global::Avalonia.Interactivity;
+using global::Avalonia.Layout;
+using global::Avalonia.Threading;
+using global::Avalonia.VisualTree;
+using MPF.Avalonia.Helpers;
+
+namespace MPF.Avalonia.Windows
+{
+    /// <summary>
+    /// Separate window that streams a dumping tool's live standard output and error.
+    /// </summary>
+    /// <remarks>
+    /// Shown modeless (via <c>Show(owner)</c>) so the MPF main window never freezes and
+    /// its Stop button stays reachable. Raw output chunks arrive on <see cref="Append"/>
+    /// from background reader threads; a bounded <see cref="OutputPump"/> batches them and
+    /// a <see cref="TerminalBuffer"/> applies terminal line-discipline so a tool's bare
+    /// <c>\r</c> progress redraws collapse onto a single live line instead of flooding the
+    /// scrollback. Committed lines feed a virtualized list with a CMD-style fixed cap.
+    /// </remarks>
+    public partial class ToolOutputWindow : Window
+    {
+        /// <summary>
+        /// CMD-style fixed scrollback: oldest lines are trimmed past this cap
+        /// </summary>
+        private const int MaxLines = 10_000;
+
+        /// <summary>
+        /// One batched UI dispatch per ~60 fps frame
+        /// </summary>
+        private const int FlushIntervalMs = 16;
+
+        private readonly ObservableCollection<string> _lines = new();
+        private readonly TerminalBuffer _buffer = new();
+        private readonly OutputPump _pump = new(capacity: 8192);
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _pumpTask;
+
+        /// <summary>
+        /// Committed lines already pushed to the UI
+        /// </summary>
+        private int _committedIndex;
+
+        /// <summary>
+        /// Follow the tail; toggled only by user input
+        /// </summary>
+        private bool _autoScroll = true;
+
+        /// <summary>
+        /// Coalesces deferred ScrollToEnd posts
+        /// </summary>
+        private bool _scrollQueued;
+
+        /// <summary>
+        /// Vertical scrollbar Scroll event subscribed
+        /// </summary>
+        private bool _scrollBarHooked;
+
+        /// <summary>
+        /// ListBox's inner scroll viewer (found lazily)
+        /// </summary>
+        private ScrollViewer? _scroller;
+
+        /// <summary>
+        /// Raised when the user toggles the auto-close checkbox, so the host can persist it
+        /// </summary>
+        public event Action<bool>? AutoCloseChanged;
+
+        public ToolOutputWindow() : this(autoClose: true) { }
+
+        public ToolOutputWindow(bool autoClose)
+        {
+            InitializeComponent();
+
+            LinesList.ItemsSource = _lines;
+
+            CopyMenuItem.Click += (_, _) => CopySelectionToClipboard();
+            SelectAllMenuItem.Click += (_, _) => LinesList.SelectAll();
+            // Window-level so Ctrl+C / Ctrl+A work without giving the (deliberately
+            // non-focusable) log rows keyboard focus.
+            KeyDown += OnKeyDown;
+
+            AutoCloseCheck.IsChecked = autoClose;
+            AutoCloseCheck.IsCheckedChanged += (_, _) => AutoCloseChanged?.Invoke(AutoCloseCheck.IsChecked == true);
+
+            // The pump runs for the lifetime of the window, draining whatever Append posts.
+            _pumpTask = _pump.RunAsync(_buffer, OnBatch, FlushIntervalMs, _cts.Token);
+        }
+
+        /// <summary>
+        /// Whether the window should close itself when the tool exits
+        /// </summary>
+        public bool AutoClose
+        {
+            get => AutoCloseCheck.IsChecked == true;
+            set => AutoCloseCheck.IsChecked = value;
+        }
+
+        /// <summary>
+        /// Push a raw chunk of tool output. Thread-safe: called from reader threads.
+        /// </summary>
+        public void Append(string chunk) => _pump.Post(chunk);
+
+        /// <summary>
+        /// The tool process exited: flush the remaining output, then close if the user
+        /// opted in. Safe to call on the UI thread.
+        /// </summary>
+        public async void NotifyToolExited()
+        {
+            // Complete the pump so its final drain flushes the tail to the UI, then wait
+            // for that drain to finish before deciding whether to close.
+            _pump.Complete();
+            try
+            {
+                await _pumpTask;
+            }
+            catch
+            {
+                // shutdown races are fine
+            }
+
+            if (AutoCloseCheck.IsChecked == true)
+                Close();
+        }
+
+        /// <summary>
+        /// Ctrl+C / context-menu Copy: copy the selected log lines as plain text.
+        /// Ctrl+A selects every committed line.
+        /// </summary>
+        private void OnKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.KeyModifiers.HasFlag(KeyModifiers.Control) && e.Key == Key.C)
+            {
+                CopySelectionToClipboard();
+                e.Handled = true;
+            }
+            else if (e.KeyModifiers.HasFlag(KeyModifiers.Control) && e.Key == Key.A)
+            {
+                LinesList.SelectAll();
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>
+        /// Copies the selected rows to the clipboard, newline-joined and in top-to-bottom
+        /// (source) order regardless of the order they were clicked.
+        /// </summary>
+        private async void CopySelectionToClipboard()
+        {
+            IReadOnlyList<int> selected = LinesList.Selection?.SelectedIndexes ?? Array.Empty<int>();
+            if (selected.Count == 0)
+                return;
+
+            var sb = new StringBuilder(selected.Count * 48);
+            foreach (int idx in selected.OrderBy(i => i))
+            {
+                if (idx >= 0 && idx < _lines.Count)
+                    sb.Append(_lines[idx]);
+                sb.Append('\n');
+            }
+            if (sb.Length > 0 && sb[^1] == '\n')
+                sb.Length -= 1; // drop the trailing newline
+
+            IClipboard? clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard is not null)
+                await clipboard.SetTextAsync(sb.ToString());
+        }
+
+        /// <summary>
+        /// Runs on the consumer thread after a batch was fed to the buffer. Snapshot the
+        /// new committed lines + the current live line, then do exactly ONE dispatch to
+        /// the UI thread for the whole batch.
+        /// </summary>
+        private void OnBatch(int consumed)
+        {
+            List<string>? newLines = null;
+            List<string> committed = _buffer.CommittedLines;
+            if (_committedIndex < committed.Count)
+            {
+                newLines = new List<string>(committed.Count - _committedIndex);
+                for (; _committedIndex < committed.Count; _committedIndex++)
+                {
+                    newLines.Add(committed[_committedIndex]);
+                }
+            }
+
+            string live = _buffer.CurrentLine;
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                EnsureScroller();
+
+                if (newLines is not null)
+                {
+                    foreach (string line in newLines)
+                    {
+                        _lines.Add(line);
+                    }
+                }
+
+                // CMD-style fixed scrollback: always drop the oldest lines past the cap.
+                while (_lines.Count > MaxLines)
+                {
+                    _lines.RemoveAt(0);
+                }
+
+                LiveLine.Text = live;
+
+                if (_autoScroll && _scroller is not null && !_scrollQueued)
+                {
+                    _scrollQueued = true;
+                    // Defer past the layout pass so the extent is fresh and we land on the bottom.
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        _scrollQueued = false;
+                        if (_autoScroll)
+                            _scroller!.ScrollToEnd();
+                    }, DispatcherPriority.Background);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Lazily grab the ListBox's inner ScrollViewer (only exists after the control is
+        /// templated) and subscribe to its scroll changes for tail-follow tracking.
+        /// </summary>
+        private void EnsureScroller()
+        {
+            if (_scroller is null)
+            {
+                _scroller = LinesList.FindDescendantOfType<ScrollViewer>();
+                if (_scroller is not null)
+                    LinesList.PointerWheelChanged += OnWheel;
+            }
+
+            // The vertical ScrollBar realizes slightly later than the ScrollViewer.
+            if (_scroller is not null && !_scrollBarHooked)
+            {
+                ScrollBar? vbar = _scroller.GetVisualDescendants()
+                    .OfType<ScrollBar>()
+                    .FirstOrDefault(sb => sb.Orientation == Orientation.Vertical);
+                if (vbar is not null)
+                {
+                    vbar.Scroll += OnUserScroll;
+                    _scrollBarHooked = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tail-follow is toggled ONLY by genuine user input: the scrollbar's Scroll event
+        /// (thumb drag / track / page) and the mouse wheel. Neither fires for the
+        /// programmatic ScrollToEnd or for the ring-buffer trim -- so following never drops
+        /// on its own under fast output. Position then decides direction: at/near the
+        /// bottom = follow, else not.
+        /// </summary>
+        private void OnUserScroll(object? sender, ScrollEventArgs e)
+            => SyncFollowToPosition();
+
+        private void OnWheel(object? sender, PointerWheelEventArgs e)
+            // The wheel scroll is applied after this event fires; check once it has.
+            => Dispatcher.UIThread.Post(SyncFollowToPosition, DispatcherPriority.Background);
+
+        private void SyncFollowToPosition()
+        {
+            if (_scroller is null)
+                return;
+
+            double distanceFromBottom = _scroller.Extent.Height - _scroller.Viewport.Height - _scroller.Offset.Y;
+            _autoScroll = distanceFromBottom <= 4;
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            // Best-effort shutdown; if the tool is still running its output is simply
+            // dropped from here on (Post on a completed channel is a no-op).
+            _cts.Cancel();
+            _pump.Complete();
+            base.OnClosed(e);
+        }
+    }
+}

--- a/MPF.ExecutionContexts/BaseExecutionContext.cs
+++ b/MPF.ExecutionContexts/BaseExecutionContext.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading;
 using SabreTools.RedumpLib.Data;
 
 namespace MPF.ExecutionContexts
@@ -44,6 +46,18 @@ namespace MPF.ExecutionContexts
         /// Process to track external program
         /// </summary>
         private Process? process;
+
+        /// <summary>
+        /// Optional sink for the tool's raw standard output and error
+        /// </summary>
+        /// <remarks>
+        /// When set, the program is launched with its output redirected and streamed
+        /// here in raw chunks (carriage returns preserved), instead of letting the tool
+        /// draw its own console window. Used by a GUI frontend to display live tool
+        /// output on platforms without an external console. Leave null for the legacy
+        /// behavior, where the tool owns its console window (UseShellExecute).
+        /// </remarks>
+        public Action<string>? OutputReceived { get; set; }
 
         #endregion
 
@@ -195,15 +209,20 @@ namespace MPF.ExecutionContexts
         /// </summary>
         public void ExecuteInternalProgram()
         {
+            // When no output sink is attached, keep the original behavior exactly: the
+            // tool runs in its own console window (UseShellExecute) with no redirection.
+            // When a sink is attached, redirect output and stream it to the caller.
+            bool redirect = OutputReceived is not null;
+
             // Create the start info
             var startInfo = new ProcessStartInfo()
             {
                 FileName = ExecutablePath!,
                 Arguments = GenerateParameters() ?? "",
-                CreateNoWindow = false,
-                UseShellExecute = true,
-                RedirectStandardOutput = false,
-                RedirectStandardError = false,
+                CreateNoWindow = redirect,
+                UseShellExecute = !redirect,
+                RedirectStandardOutput = redirect,
+                RedirectStandardError = redirect,
             };
 
             // Create the new process
@@ -211,8 +230,61 @@ namespace MPF.ExecutionContexts
 
             // Start the process
             process.Start();
-            process.WaitForExit();
+
+            if (redirect)
+            {
+                // Pump stdout and stderr on dedicated threads using RAW reads (never
+                // ReadLine): dump tools redraw progress with a bare '\r', and ReadLine
+                // would treat every '\r' as a new line -- the exact spam/lag that made
+                // redirected output unusable before. The consumer interprets '\r'.
+                Thread outThread = StartStreamPump(process.StandardOutput);
+                Thread errThread = StartStreamPump(process.StandardError);
+
+                process.WaitForExit();
+                outThread.Join();
+                errThread.Join();
+            }
+            else
+            {
+                process.WaitForExit();
+            }
+
             process.Close();
+        }
+
+        /// <summary>
+        /// Start a background thread that copies a redirected stream to <see cref="OutputReceived"/>
+        /// in raw chunks
+        /// </summary>
+        /// <remarks>
+        /// Blocking reads on a dedicated thread keep this compatible across every target
+        /// framework (no async or channels needed here). Multiple pumps may run at once;
+        /// the sink is expected to be safe to call from several threads.
+        /// </remarks>
+        private Thread StartStreamPump(StreamReader reader)
+        {
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var buffer = new char[4096];
+                    int read;
+                    while ((read = reader.Read(buffer, 0, buffer.Length)) > 0)
+                    {
+                        OutputReceived?.Invoke(new string(buffer, 0, read));
+                    }
+                }
+                catch
+                {
+                    // The stream is closed when the process exits or is killed; nothing to do.
+                }
+            })
+            {
+                IsBackground = true,
+                Name = "MPF tool output pump",
+            };
+            thread.Start();
+            return thread;
         }
 
         /// <summary>

--- a/MPF.Frontend/DumpEnvironment.cs
+++ b/MPF.Frontend/DumpEnvironment.cs
@@ -97,6 +97,17 @@ namespace MPF.Frontend
         /// </summary>
         public EventHandler<StringEventArgs>? ReportStatus;
 
+        /// <summary>
+        /// Optional sink for the dumping tool's raw output
+        /// </summary>
+        /// <remarks>
+        /// When set, the tool runs with its standard output and error redirected and
+        /// streamed here. Used by a GUI frontend to show live tool output in a separate
+        /// window on platforms without an external console. Leave null for the legacy
+        /// behavior, where the tool owns its own console window.
+        /// </remarks>
+        public Action<string>? ToolOutputReceived { get; set; }
+
         #endregion
 
         /// <summary>
@@ -488,6 +499,10 @@ namespace MPF.Frontend
             var directoryName = Path.GetDirectoryName(OutputPath);
             if (!string.IsNullOrEmpty(directoryName))
                 Directory.CreateDirectory(directoryName);
+
+            // Stream the tool's raw output to the attached sink, if any (GUI console).
+            // Null leaves the execution context on its legacy, non-redirected path.
+            _executionContext.OutputReceived = ToolOutputReceived;
 
 #if NET40
             await Task.Factory.StartNew(() => { _executionContext.ExecuteInternalProgram(); return true; });

--- a/MPF.Frontend/IToolOutputConsole.cs
+++ b/MPF.Frontend/IToolOutputConsole.cs
@@ -1,0 +1,39 @@
+namespace MPF.Frontend
+{
+    /// <summary>
+    /// Abstraction for a live tool-output console shown by a GUI frontend while a
+    /// dumping program runs.
+    /// </summary>
+    /// <remarks>
+    /// Implemented by a frontend that can display the tool's redirected output in its
+    /// own surface (for example, a separate window on Linux, where the dumping tool has
+    /// no console window of its own). Frontends that rely on the tool drawing its own
+    /// console window (Windows) leave this null, preserving the original behavior.
+    /// </remarks>
+    public interface IToolOutputConsole
+    {
+        /// <summary>
+        /// Show the console. Called on the UI thread just before the tool starts.
+        /// </summary>
+        void Open();
+
+        /// <summary>
+        /// Receive a raw chunk of the tool's standard output or error.
+        /// </summary>
+        /// <param name="chunk">Raw output chunk, with carriage returns preserved</param>
+        /// <remarks>
+        /// Thread-safe: called from background reader threads, so implementations must
+        /// not touch UI state directly here.
+        /// </remarks>
+        void Append(string chunk);
+
+        /// <summary>
+        /// Signal that the tool process has exited. Called on the UI thread.
+        /// </summary>
+        /// <remarks>
+        /// The implementation closes the console or leaves it open per the user's
+        /// preference.
+        /// </remarks>
+        void NotifyToolExited();
+    }
+}

--- a/MPF.Frontend/Options.cs
+++ b/MPF.Frontend/Options.cs
@@ -88,6 +88,7 @@ namespace MPF.Frontend
 
             GUI.CopyUpdateUrlToClipboard = source.GUI.CopyUpdateUrlToClipboard;
             GUI.OpenLogWindowAtStartup = source.GUI.OpenLogWindowAtStartup;
+            GUI.ToolConsoleAutoClose = source.GUI.ToolConsoleAutoClose;
 
             GUI.DefaultInterfaceLanguage = source.GUI.DefaultInterfaceLanguage;
             GUI.ShowDebugViewMenuItem = source.GUI.ShowDebugViewMenuItem;
@@ -443,6 +444,12 @@ namespace MPF.Frontend
         /// </summary>
         /// <remarks>Version 1 and greater</remarks>
         public bool OpenLogWindowAtStartup { get; set; } = true;
+
+        /// <summary>
+        /// Automatically close the separate tool-output window when the dumping program exits
+        /// </summary>
+        /// <remarks>Version 1 and greater; currently used by the Linux GUI tool-output window</remarks>
+        public bool ToolConsoleAutoClose { get; set; } = true;
 
         #endregion
 

--- a/MPF.Frontend/Tools/OptionsLoader.cs
+++ b/MPF.Frontend/Tools/OptionsLoader.cs
@@ -367,6 +367,7 @@ namespace MPF.Frontend.Tools
 
             options.GUI.CopyUpdateUrlToClipboard = GetBooleanSetting(source, "CopyUpdateUrlToClipboard", true);
             options.GUI.OpenLogWindowAtStartup = GetBooleanSetting(source, "OpenLogWindowAtStartup", true);
+            options.GUI.ToolConsoleAutoClose = GetBooleanSetting(source, "ToolConsoleAutoClose", true);
 
             valueString = GetStringSetting(source, "DefaultInterfaceLanguage", InterfaceLanguage.AutoDetect.ShortName());
             options.GUI.DefaultInterfaceLanguage = valueString.ToInterfaceLanguage();
@@ -541,6 +542,7 @@ namespace MPF.Frontend.Tools
 
                 { "VerboseLogging", options.VerboseLogging.ToString() },
                 { "OpenLogWindowAtStartup", options.GUI.OpenLogWindowAtStartup.ToString() },
+                { "ToolConsoleAutoClose", options.GUI.ToolConsoleAutoClose.ToString() },
 
                 { "RetrieveMatchInformation", options.Processing.Login.RetrieveMatchInformation.ToString() },
                 { "RedumpOrgUsername", options.Processing.Login.RedumpOrgUsername },

--- a/MPF.Frontend/ViewModels/MainViewModel.cs
+++ b/MPF.Frontend/ViewModels/MainViewModel.cs
@@ -71,6 +71,11 @@ namespace MPF.Frontend.ViewModels
         /// </summary>
         private ProcessUserInfoDelegate? _processUserInfo;
 
+        /// <summary>
+        /// Optional live tool-output console supplied by the frontend (null if unused)
+        /// </summary>
+        private IToolOutputConsole? _toolConsole;
+
         #endregion
 
         #region Properties
@@ -597,12 +602,14 @@ namespace MPF.Frontend.ViewModels
         public void Init(
             Action<LogLevel, string> loggerAction,
             Func<string, string, int, bool, bool?> displayUserMessage,
-            ProcessUserInfoDelegate processUserInfo)
+            ProcessUserInfoDelegate processUserInfo,
+            IToolOutputConsole? toolConsole = null)
         {
             // Set the callbacks
             _logger = loggerAction;
             _displayUserMessage = displayUserMessage;
             _processUserInfo = processUserInfo;
+            _toolConsole = toolConsole;
 
             // Finish initializing the rest of the values
             InitializeUIValues(removeEventHandlers: false, rebuildPrograms: true, rescanDrives: true);
@@ -2259,8 +2266,19 @@ namespace MPF.Frontend.ViewModels
                 protectionProgress.ProgressChanged += ProgressUpdated;
                 _environment.ReportStatus += ProgressUpdated;
 
+                // Stream live tool output to the separate console window, if the frontend
+                // provides one (Linux GUI). Harmless no-op for frontends that do not.
+                if (_toolConsole is not null)
+                {
+                    _toolConsole.Open();
+                    _environment.ToolOutputReceived = _toolConsole.Append;
+                }
+
                 // Run the program with the parameters
                 ResultEventArgs result = await _environment.Run(CurrentPhysicalMediaType, resultProgress);
+
+                // The tool has exited; let the console close itself per the user's preference
+                _toolConsole?.NotifyToolExited();
 
                 // If we didn't execute a dumping command we cannot get submission output
                 if (!_environment.IsDumpingCommand())


### PR DESCRIPTION
## What

On Linux the dumping tools (redumper, DiscImageCreator, Aaru) run without a console window of their own, so their live progress output was not visible anywhere in the GUI. This adds an in-app **Program Output** window that streams the tool's stdout/stderr live while it runs.

## Scope: Linux only, for now

The console is wired up **only on Linux**. On Windows, macOS, the WPF GUI and the CLI nothing changes — the output sink stays `null`, so the original `UseShellExecute` launch path is used exactly as before. I kept this conservative for the first cut; if you're happy with the approach, a natural follow-up would be to unify it across all platforms (and drop the separate CMD window on Windows). Happy to discuss.

## How it works

- **MPF.ExecutionContexts** – `BaseExecutionContext` gains an optional `Action<string>? OutputReceived`. When set, the tool is started with `RedirectStandardOutput/Error` and read raw (char-level, carriage-return aware) on two background threads, so `\r` progress redraws don't flood the log. When `null` (every current caller), the launch path is unchanged. Kept net20-safe (no Channels/async) for the multi-targeted projects.
- **MPF.Frontend** – `DumpEnvironment.ToolOutputReceived` forwards the stream. A minimal `IToolOutputConsole` seam (Open / Append / NotifyToolExited) lets a frontend present the output without the frontend layer taking a UI dependency. New `GuiSettings.ToolConsoleAutoClose` option, round-tripped through `OptionsLoader`.
- **MPF.Avalonia** – `ToolOutputWindow` renders the stream in a virtualized, terminal-style view (fixed-height rows, `\r`/`\n` line discipline, copy / select-all). Shown **modeless and owned** beside the main window, so the main window and its Stop button stay fully responsive. An "auto-close when the program exits" checkbox (default on) is persisted to the config.

## Localization

New user-facing strings added to `Strings.xaml` and `Strings.de.xaml`.

## Testing

- Full solution builds clean across all target frameworks (net20 → net10.0): 0 warnings, 0 errors.
- `MPF.ExecutionContexts.Test` (615) and `MPF.Frontend.Test` (529) pass with 0 failures on net8.0/net9.0/net10.0.
- Manually verified on Fedora KDE (Avalonia, .NET 10) with real redumper and DiscImageCreator dumps of a PhotoCD disc: live output streams correctly, the window stays responsive, Stop works, and the auto-close preference persists across restarts.

---
*Prepared with AI assistance (Claude Opus 4.8) and reviewed before submission.*
