### PR TITLE
Pre-compress subcode files with Zstd

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,3 +1,6 @@
+### WIP (xxxx-xx-xx)
+- Pre-compress subcode files with Zstd
+
 ### 3.8.3 (2026-07-06)
 
 - Add live tool output console for the Linux GUI (gmipf)

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,4 +1,5 @@
 ### WIP (xxxx-xx-xx)
+
 - Pre-compress subcode files with Zstd
 
 ### 3.8.3 (2026-07-06)

--- a/MPF.Processors.Test/RedumperTests.cs
+++ b/MPF.Processors.Test/RedumperTests.cs
@@ -103,7 +103,7 @@ namespace MPF.Processors.Test
             var processor = new Redumper(PhysicalSystem.IBMPCcompatible);
 
             var actual = processor.GetOutputFiles(PhysicalMediaType.CDROM, outputDirectory, outputFilename);
-            Assert.Equal(19, actual.Count);
+            Assert.Equal(20, actual.Count);
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace MPF.Processors.Test
             string outputFilename = string.Empty;
             var processor = new Redumper(PhysicalSystem.IBMPCcompatible);
             var actual = processor.FoundAllFiles(PhysicalMediaType.CDROM, outputDirectory, outputFilename);
-            Assert.Equal(5, actual.Count);
+            Assert.Equal(4, actual.Count);
         }
 
         [Fact]

--- a/MPF.Processors/Redumper.cs
+++ b/MPF.Processors/Redumper.cs
@@ -573,8 +573,10 @@ namespace MPF.Processors
                         new($"{outputFilename}.state.zst", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "state_zst"),
-                        new([$"{outputFilename}.subcode", $"{outputFilename}.subcode.zst"], OutputFileFlags.Required
-                            | OutputFileFlags.Binary
+                        new($"{outputFilename}.subcode", OutputFileFlags.Binary
+                            | OutputFileFlags.Zippable,
+                            "subcode"),
+                        new($"{outputFilename}.subcode.zst", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "subcode"),
                         new($"{outputFilename}.toc", OutputFileFlags.Required

--- a/MPF.Processors/Redumper.cs
+++ b/MPF.Processors/Redumper.cs
@@ -127,6 +127,8 @@ namespace MPF.Processors
                 _ = CompressZstandard($"{basePath}.skeleton");
             if (File.Exists($"{basePath}.state"))
                 _ = CompressZstandard($"{basePath}.state");
+            if (File.Exists($"{basePath}.subcode"))
+                _ = CompressZstandard($"{basePath}.subcode");
 
             // Pre-compress all skeletons for multi-track CDs
             if (File.Exists($"{basePath}.cue"))
@@ -571,7 +573,7 @@ namespace MPF.Processors
                         new($"{outputFilename}.state.zst", OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "state_zst"),
-                        new($"{outputFilename}.subcode", OutputFileFlags.Required
+                        new([$"{outputFilename}.subcode", $"{outputFilename}.subcode.zst"], OutputFileFlags.Required
                             | OutputFileFlags.Binary
                             | OutputFileFlags.Zippable,
                             "subcode"),


### PR DESCRIPTION
Similar to state and skeleton, pre-compressing subcode file can have significant savings for the log zip size for some CDs