### PR TITLE
Do not let a failed file dialog terminate MPF

### DIFF
--- a/MPF.Avalonia/Services/DialogService.cs
+++ b/MPF.Avalonia/Services/DialogService.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
+using MPF.Avalonia.Windows;
 
 namespace MPF.Avalonia.Services
 {
@@ -18,14 +20,22 @@ namespace MPF.Avalonia.Services
             if (owner.StorageProvider is null)
                 return null;
 
-            var files = await owner.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            try
             {
-                Title = title,
-                AllowMultiple = false,
-                FileTypeFilter = fileTypes,
-            });
+                var files = await owner.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                {
+                    Title = title,
+                    AllowMultiple = false,
+                    FileTypeFilter = fileTypes,
+                });
 
-            return files.Count > 0 ? files[0].TryGetLocalPath() : null;
+                return files.Count > 0 ? files[0].TryGetLocalPath() : null;
+            }
+            catch (Exception ex)
+            {
+                await ReportFailureAsync(owner, ex);
+                return null;
+            }
         }
 
         /// <summary>
@@ -36,13 +46,21 @@ namespace MPF.Avalonia.Services
             if (owner.StorageProvider is null)
                 return null;
 
-            var folders = await owner.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+            try
             {
-                Title = title,
-                AllowMultiple = false,
-            });
+                var folders = await owner.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+                {
+                    Title = title,
+                    AllowMultiple = false,
+                });
 
-            return folders.Count > 0 ? folders[0].TryGetLocalPath() : null;
+                return folders.Count > 0 ? folders[0].TryGetLocalPath() : null;
+            }
+            catch (Exception ex)
+            {
+                await ReportFailureAsync(owner, ex);
+                return null;
+            }
         }
 
         /// <summary>
@@ -53,14 +71,38 @@ namespace MPF.Avalonia.Services
             if (owner.StorageProvider is null)
                 return null;
 
-            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            try
             {
-                Title = title,
-                SuggestedFileName = suggestedName,
-                FileTypeChoices = fileTypes,
-            });
+                var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+                {
+                    Title = title,
+                    SuggestedFileName = suggestedName,
+                    FileTypeChoices = fileTypes,
+                });
 
-            return file?.TryGetLocalPath();
+                return file?.TryGetLocalPath();
+            }
+            catch (Exception ex)
+            {
+                await ReportFailureAsync(owner, ex);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Tell the user that the dialog could not be shown
+        /// </summary>
+        /// <remarks>
+        /// The storage provider hands the request to the platform's file chooser, which can fail:
+        /// on Linux it lives out of process behind xdg-desktop-portal and refuses the call outright
+        /// when it cannot identify the caller. Every caller reaches these methods from an async void
+        /// event handler, so an escaping exception is unhandled and takes MPF down. Report the
+        /// failure and return no path, which callers already treat as a cancelled dialog.
+        /// </remarks>
+        private static async Task ReportFailureAsync(Window owner, Exception ex)
+        {
+            string message = $"The file dialog could not be shown:{Environment.NewLine}{Environment.NewLine}{ex.Message}";
+            await MessageBoxWindow.ShowAsyncResult(owner, "File Dialog Error", message, 1, false);
         }
     }
 }


### PR DESCRIPTION
### Problem

`MPF.Avalonia/Services/DialogService.cs` calls the Avalonia storage provider without a guard. The provider hands the request to the platform's file chooser, which can fail. Every caller reaches `DialogService` from an `async void` event handler, and there is no global exception handler, so the exception is unhandled and terminates the process.

Eleven browse handlers across five files go through these three methods:

- `MPF.Avalonia/Windows/MainWindow.axaml.cs`
- `MPF.Avalonia/Windows/OptionsWindow.axaml.cs` (4 handlers)
- `MPF.Avalonia/Windows/CreateIRDWindow.axaml.cs` (5 handlers)
- `MPF.Avalonia/Windows/CheckDumpWindow.axaml.cs`
- `MPF.Avalonia/UserControls/LogOutput.axaml.cs`

### Reproduction

Fedora 44 (KDE Plasma), packaged 3.8.3. The process is made non-dumpable with `prctl(PR_SET_DUMPABLE, 0)`, which is the state a file capability puts a binary into. `xdg-desktop-portal` then cannot read `/proc/<pid>/root` to identify the caller and refuses the call. One click on the browse button next to the output path, and MPF is gone: SIGABRT, no message, nothing in the log.

```
Unhandled exception. Tmds.DBus.Protocol.DBusException:
  org.freedesktop.DBus.Error.AccessDenied:
  Portal operation not allowed: Unable to open /proc/2998/root
   at Tmds.DBus.Protocol.DBusConnection.CallMethodAsync[T](...)
   at Avalonia.FreeDesktop.DBusSystemDialog.SaveFilePickerCoreAsync(FilePickerSaveOptions options)
   at Avalonia.Platform.Storage.FallbackStorageProvider.SaveFilePickerAsync(FilePickerSaveOptions options)
   at MPF.Avalonia.Services.DialogService.SaveFileAsync(Window owner, String title, ...)
   at MPF.Avalonia.Windows.MainWindow.BrowseOutputFileAsync()
   at MPF.Avalonia.Windows.MainWindow.OutputPathBrowseButtonClick(Object sender, RoutedEventArgs e)
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__124_0(Object state)
   at Avalonia.Threading.Dispatcher.ExecuteJobsCore(Boolean fromExplicitBackgroundProcessingCallback)
```

The last frames are the cause: the exception is rethrown from the `async void` handler onto the dispatcher, where nothing catches it.

A file capability is only one way to get there. On Linux, any portal that cannot identify the caller ends the same way: a sandbox, a Flatpak without a matching portal backend, or a broken or missing `xdg-desktop-portal`.

### Change

Catch the failure in the three `DialogService` methods, report it through the existing `MessageBoxWindow`, and return no path, which every caller already treats as a cancelled dialog. Because all eleven handlers go through these methods, one guard covers them all.

Under the same conditions MPF now stays up and shows:

> The file dialog could not be shown:
>
> org.freedesktop.DBus.Error.AccessDenied: Portal operation not allowed: Unable to open /proc/3416/root

The guard is platform-neutral and changes nothing when the chooser works. Verified on macOS 26 as well, where the provider is `Avalonia.Native.StorageProviderImpl`: the native save panel still opens normally.

---
*Prepared with AI assistance (Claude Opus 4.8) and reviewed before submission.*
