### PR TITLE
Bind the main window to properties that exist

### DIFF
--- a/MPF.Avalonia/Windows/MainWindow.axaml
+++ b/MPF.Avalonia/Windows/MainWindow.axaml
@@ -208,7 +208,7 @@
                                       Grid.Column="1"
                                       ItemsSource="{Binding MediaTypes}"
                                       SelectedItem="{Binding CurrentPhysicalMediaType, Converter={StaticResource ElementConverter}, Mode=TwoWay}"
-                                      IsEnabled="{Binding MediaTypeComboBoxEnabled}" />
+                                      IsEnabled="{Binding PhysicalMediaTypeComboBoxEnabled}" />
                         </Grid>
 
                         <TextBlock Grid.Row="1"
@@ -341,7 +341,7 @@
                     <TextBlock Text="{DynamicResource StatusGroupBoxString}"
                                FontWeight="Bold" />
                     <TextBlock x:Name="StatusLabel"
-                               Text="{Binding StatusFirstLine}"
+                               Text="{Binding Status}"
                                TextWrapping="Wrap"
                                HorizontalAlignment="Center"
                                TextAlignment="Center"

--- a/MPF.UI/Windows/MainWindow.xaml
+++ b/MPF.UI/Windows/MainWindow.xaml
@@ -352,7 +352,7 @@
                               HorizontalAlignment="Right"
                               ItemsSource="{Binding MediaTypes}"
                               SelectedItem="{Binding Path=CurrentPhysicalMediaType, Converter={StaticResource ElementConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                              IsEnabled="{Binding MediaTypeComboBoxEnabled}"
+                              IsEnabled="{Binding PhysicalMediaTypeComboBoxEnabled}"
                               Style="{DynamicResource CustomComboBoxStyle}"
                               Visibility="Hidden"/>
 


### PR DESCRIPTION
### Problem

Two bindings in the main window name properties that `MainViewModel` does not have, so they silently do nothing. Avalonia reports both at runtime:

```
[Binding]An error occurred binding 'Text' to 'StatusFirstLine' at 'StatusFirstLine':
  'Could not find a matching property accessor for 'StatusFirstLine'
  on 'MPF.Frontend.ViewModels.MainViewModel'.' (TextBlock #StatusLabel)

[Binding]An error occurred binding 'IsEnabled' to 'MediaTypeComboBoxEnabled' at 'MediaTypeComboBoxEnabled':
  'Could not find a matching property accessor for 'MediaTypeComboBoxEnabled'
  on 'MPF.Frontend.ViewModels.MainViewModel'.' (ComboBox #MediaTypeComboBox)
```

**(a) The status field stays empty.** `MPF.Avalonia/Windows/MainWindow.axaml:344` binds `StatusFirstLine`, which only exists on `CheckDumpViewModel` (`MPF.Frontend/ViewModels/CheckDumpViewModel.cs:159`), the data context of the check dump window. The main window's data context is `MainViewModel`, which exposes the text as `Status` (`MPF.Frontend/ViewModels/MainViewModel.cs:451`) — which is what the WPF main window already binds (`MPF.UI/Windows/MainWindow.xaml:510`). The status field therefore shows nothing for the whole session.

**(b) A rename that both XAML files missed.** The view model property is `PhysicalMediaTypeComboBoxEnabled` (`MPF.Frontend/ViewModels/MainViewModel.cs:184`), but the old name is still bound in

- `MPF.Avalonia/Windows/MainWindow.axaml:211`
- `MPF.UI/Windows/MainWindow.xaml:355`

`IsEnabled` falls back to its default of `true`, so the media type box stays usable while the view model wants it locked. That includes the length of a dump: `MainViewModel` sets the property to `false` when dumping starts and back to `true` when it ends. WPF only looks unaffected because it reports binding errors to the debug trace rather than to the log, so it is fixed here as well.

### Change

Bind to the properties that exist. After the change both warnings are gone and the status field reads "CD-ROM ready to dump", as it does on WPF.

Verified on Fedora 44 (KDE Plasma) against the packaged 3.8.3 build, with a trace listener attached so that Avalonia's binding warnings are visible: two warnings before, none after.

---
*Prepared with AI assistance (Claude Opus 4.8) and reviewed before submission.*
