### PR TITLE
Set a terminal type for dumping tools when their output is not a terminal

### DIFF
--- a/MPF.ExecutionContexts/BaseExecutionContext.cs
+++ b/MPF.ExecutionContexts/BaseExecutionContext.cs
@@ -225,15 +225,28 @@ namespace MPF.ExecutionContexts
                 RedirectStandardError = redirect,
             };
 
-            // With output redirected, a tool's stdout is no longer a terminal. Some tools
-            // (notably Aaru 5) still query the console width while drawing progress; on a
-            // non-terminal that width is only recoverable from the TERM/terminfo fallback,
-            // and when TERM is unset the width comes back as 0 and the tool aborts on the
-            // very first progress update. Provide a terminal type so the fallback yields a
-            // sane width. Only fill it in when the environment has none, to respect a real
-            // terminal that the frontend may have been launched from.
-            if (redirect && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TERM")))
+            // A tool started with UseShellExecute inherits the frontend's own stdout, so a
+            // frontend whose output is redirected (MPF.CLI in a script or a service) hands
+            // the tool a non-terminal too, even though nothing is redirected here. Unix
+            // only: TERM means nothing on Windows, and there an environment entry cannot be
+            // combined with UseShellExecute.
+#if NET5_0_OR_GREATER
+            bool inheritsRedirectedOutput = !redirect && !OperatingSystem.IsWindows() && Console.IsOutputRedirected;
+#else
+            bool inheritsRedirectedOutput = false;
+#endif
+
+            // Without a terminal on stdout, some tools (notably Aaru 5) still query the
+            // console width while drawing progress; that width is then only recoverable
+            // from the TERM/terminfo fallback, and when TERM is unset it comes back as 0,
+            // so the tool aborts on the very first progress update. Provide a terminal type
+            // so the fallback yields a sane width. Only fill it in when the environment has
+            // none, to respect a real terminal the frontend may have been launched from.
+            if ((redirect || inheritsRedirectedOutput)
+                && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TERM")))
+            {
                 startInfo.EnvironmentVariables["TERM"] = "xterm";
+            }
 
             // Create the new process
             process = new Process() { StartInfo = startInfo };

--- a/MPF.ExecutionContexts/BaseExecutionContext.cs
+++ b/MPF.ExecutionContexts/BaseExecutionContext.cs
@@ -225,6 +225,16 @@ namespace MPF.ExecutionContexts
                 RedirectStandardError = redirect,
             };
 
+            // With output redirected, a tool's stdout is no longer a terminal. Some tools
+            // (notably Aaru 5) still query the console width while drawing progress; on a
+            // non-terminal that width is only recoverable from the TERM/terminfo fallback,
+            // and when TERM is unset the width comes back as 0 and the tool aborts on the
+            // very first progress update. Provide a terminal type so the fallback yields a
+            // sane width. Only fill it in when the environment has none, to respect a real
+            // terminal that the frontend may have been launched from.
+            if (redirect && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TERM")))
+                startInfo.EnvironmentVariables["TERM"] = "xterm";
+
             // Create the new process
             process = new Process() { StartInfo = startInfo };
 


### PR DESCRIPTION
## Problem

Aaru 5 queries the console width (`Console.WindowWidth`) while drawing progress. When its standard output is not a terminal, that width can only come from the `TERM`/terminfo fallback, and **when `TERM` is unset it comes back as `0`**. Aaru 5 then evaluates `new string(' ', width - 1)` and throws `ArgumentOutOfRangeException` on the very first progress update, before it reads a single sector.

MPF hands Aaru 5 a non-terminal stdout in two independent situations:

1. **GUI** — the Linux tool-output console (added in #998) redirects the tool's stdout to a pipe so it can be shown in a window.
2. **CLI** — `MPF.CLI` launches the tool with `UseShellExecute = true`, so the tool inherits `MPF.CLI`'s own stdout. When `MPF.CLI` itself runs without a terminal (a script, a service, cron, or `mpf-cli … > log`), the tool inherits that non-terminal. This path predates #998 and is not specific to the GUI.

Whether it bites also depends on the environment's `TERM`:

| Launched from | `TERM` seen by the tool | Aaru 5 result |
|---|---|---|
| GNOME menu (GNOME Shell 50.1) | *(unset)* | **aborts** before first read |
| KDE Plasma menu | `dumb` (has a terminfo width) | dumps fine |
| a terminal | `xterm` etc. | dumps fine |

So from GNOME — or any environment that does not export `TERM`, including non-interactive service/cron contexts — Aaru 5 cannot dump at all, while the same build works from KDE or a terminal.

## Fix

When the tool's stdout will not be a terminal and the environment has no `TERM`, set `TERM` to a type with a known width. This covers both the redirected (GUI) path and the inherited-output (CLI) path. A real terminal's `TERM` is left untouched. The inherited-output check is limited to .NET 5+ on non-Windows: `TERM` is meaningless on Windows, and there an environment entry cannot be combined with `UseShellExecute`.

```csharp
#if NET5_0_OR_GREATER
bool inheritsRedirectedOutput = !redirect && !OperatingSystem.IsWindows() && Console.IsOutputRedirected;
#else
bool inheritsRedirectedOutput = false;
#endif

if ((redirect || inheritsRedirectedOutput)
    && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TERM")))
{
    startInfo.EnvironmentVariables["TERM"] = "xterm";
}
```

## Testing

Measured on real hardware (Plextor PX-760A, audio CD) in a clean VM, driving the real `BaseExecutionContext.ExecuteInternalProgram` path with `TERM` unset (the GNOME / service condition). Images are time-boxed, so sizes are not comparable between tools:

| Tool (via MPF.CLI, `TERM` unset, no terminal) | before | after |
|---|---|---|
| Aaru 5.4.2 | `ArgumentOutOfRangeException`, no image | dumps (≈102 MB) |
| redumper | dumps (≈229 MB) | dumps (≈229 MB) |
| DiscImageCreator | dumps (≈61 MB) | dumps (≈61 MB) |
| Aaru 6.0.0-beta.1 | not invokable by MPF today¹ | not invokable by MPF today¹ |

- Only Aaru 5 is affected: `redumper` and DiscImageCreator are native tools that do not use the managed console-width API, and they are unchanged by this PR.
- ¹ MPF invokes Aaru with 5.x syntax (`--verbose True media dump …`); Aaru 6 rejects it at parse time (`Unexpected option 'verbose'`), so it never reaches this code. Mentioned only for completeness.
- The CLI path is pre-existing: I built `MPF.CLI` at the commit just before my first contribution and reproduced the identical crash (`ArgumentOutOfRangeException` → `Aaru.Progress.ClearCurrentConsoleLine()`) under the same condition, and confirmed it dumps with `TERM=xterm`. This change does not introduce the CLI behavior; it fixes it.
- Builds across the full `TargetFrameworks` set (net20 … net10.0) with no warnings; `MPF.ExecutionContexts.Test` 615 passed and `MPF.Frontend.Test` 562 passed.

*Prepared with AI assistance (Claude Opus 4.8) and reviewed before submission.*
