### PR TITLE
Check UI drive dropdown

### DIFF
--- a/MPF.Avalonia/Windows/CheckDumpWindow.axaml
+++ b/MPF.Avalonia/Windows/CheckDumpWindow.axaml
@@ -24,7 +24,7 @@
                     <TextBlock Text="{DynamicResource SettingsGroupBoxString}"
                                FontWeight="Bold" />
                     <Grid ColumnDefinitions="160,*,Auto"
-                          RowDefinitions="Auto,Auto,Auto"
+                          RowDefinitions="Auto,Auto,Auto,Auto"
                           ColumnSpacing="6"
                           RowSpacing="4">
                         <TextBlock Grid.Row="0"
@@ -61,10 +61,22 @@
                                   VerticalAlignment="Center" />
 
                         <TextBlock Grid.Row="2"
+                                   Text="{DynamicResource DriveLetterLabelString}"
+                                   VerticalAlignment="Center" />
+                        <ComboBox x:Name="DriveLetterComboBox"
+                                  Grid.Row="2"
+                                  Grid.Column="1"
+                                  ItemsSource="{Binding Drives}"
+                                  SelectedItem="{Binding CurrentDrive, Mode=TwoWay}"
+                                  IsEnabled="{Binding DriveLetterComboBoxEnabled}"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Center" />
+
+                        <TextBlock Grid.Row="3"
                                    Text="{DynamicResource DumpingProgramLabelString}"
                                    VerticalAlignment="Center" />
                         <ComboBox x:Name="DumpingProgramComboBox"
-                                  Grid.Row="2"
+                                  Grid.Row="3"
                                   Grid.Column="1"
                                   ItemsSource="{Binding AvailableInternalPrograms}"
                                   SelectedItem="{Binding CurrentProgram, Converter={StaticResource ElementConverter}, Mode=TwoWay}"

--- a/MPF.Frontend/ViewModels/CheckDumpViewModel.cs
+++ b/MPF.Frontend/ViewModels/CheckDumpViewModel.cs
@@ -106,6 +106,32 @@ namespace MPF.Frontend.ViewModels
         } = true;
 
         /// <summary>
+        /// Currently selected drive
+        /// </summary>
+        public Drive? CurrentDrive
+        {
+            get;
+            set
+            {
+                field = value;
+                TriggerPropertyChanged(nameof(CurrentDrive));
+            }
+        }
+
+        /// <summary>
+        /// Indicates the status of the drive letter combo box
+        /// </summary>
+        public bool DriveLetterComboBoxEnabled
+        {
+            get;
+            set
+            {
+                field = value;
+                TriggerPropertyChanged(nameof(DriveLetterComboBoxEnabled));
+            }
+        } = true;
+
+        /// <summary>
         /// Currently selected dumping program
         /// </summary>
         public InternalProgram CurrentProgram
@@ -207,6 +233,19 @@ namespace MPF.Frontend.ViewModels
         } = PhysicalSystemComboBoxItem.GenerateElements();
 
         /// <summary>
+        /// Current list of drives
+        /// </summary>
+        public List<Drive> Drives
+        {
+            get;
+            set
+            {
+                field = value;
+                TriggerPropertyChanged(nameof(Drives));
+            }
+        } = [];
+
+        /// <summary>
         /// List of available internal programs
         /// </summary>
         public List<Element<InternalProgram>> AvailableInternalPrograms
@@ -248,6 +287,7 @@ namespace MPF.Frontend.ViewModels
         {
             _options = OptionsLoader.LoadFromConfig(out _);
 
+            PopulateDrives();
             PopulateInternalPrograms();
             EnableEventHandlers();
         }
@@ -311,6 +351,7 @@ namespace MPF.Frontend.ViewModels
             SystemTypeComboBoxEnabled = true;
             InputPathTextBoxEnabled = true;
             InputPathBrowseButtonEnabled = true;
+            DriveLetterComboBoxEnabled = true;
             DumpingProgramComboBoxEnabled = true;
             CheckDumpButtonEnabled = ShouldEnableCheckDumpButton();
             CancelButtonEnabled = true;
@@ -324,6 +365,7 @@ namespace MPF.Frontend.ViewModels
             SystemTypeComboBoxEnabled = false;
             InputPathTextBoxEnabled = false;
             InputPathBrowseButtonEnabled = false;
+            DriveLetterComboBoxEnabled = false;
             DumpingProgramComboBoxEnabled = false;
             CheckDumpButtonEnabled = false;
             CancelButtonEnabled = false;
@@ -332,6 +374,22 @@ namespace MPF.Frontend.ViewModels
         #endregion
 
         #region Population
+
+        /// <summary>
+        /// Populate the list of drives
+        /// </summary>
+        private void PopulateDrives()
+        {
+            bool cachedCanExecuteSelectionChanged = CanExecuteSelectionChanged;
+            DisableEventHandlers();
+
+            Drives = Drive.CreateListOfDrives(Options.GUI.IgnoreFixedDrives);
+            // Default to "None" drive (don't scan)
+            CurrentDrive = null;
+
+            if (cachedCanExecuteSelectionChanged)
+                EnableEventHandlers();
+        }
 
         /// <summary>
         /// Populate media type according to system type
@@ -412,7 +470,7 @@ namespace MPF.Frontend.ViewModels
             // Populate an environment
             var env = new DumpEnvironment(Options,
                 Path.GetFullPath(InputPath.Trim('"')),
-                null,
+                CurrentDrive,
                 CurrentSystem,
                 CurrentProgram);
             env.SetProcessor();

--- a/MPF.UI/Windows/CheckDumpWindow.xaml
+++ b/MPF.UI/Windows/CheckDumpWindow.xaml
@@ -114,6 +114,7 @@
                         <RowDefinition/>
                         <RowDefinition/>
                         <RowDefinition/>
+                        <RowDefinition/>
                     </Grid.RowDefinitions>
 
                     <Label x:Name="InputPathLabel"
@@ -171,13 +172,29 @@
                         </ComboBox.ItemContainerStyle>
                     </ComboBox>
 
-                    <Label x:Name="DumpingProgramLabel"
+                    <Label x:Name="DriveLetterLabel"
                            Grid.Row="2"
+                           Grid.Column="0"
+                           VerticalAlignment="Center"
+                           Content="{DynamicResource DriveLetterLabelString}"/>
+                    <ComboBox x:Name="DriveLetterComboBox"
+                              Grid.Row="2"
+                              Grid.Column="1"
+                              ItemsSource="{Binding Drives}"
+                              SelectedItem="{Binding CurrentDrive, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                              IsEnabled="{Binding DriveLetterComboBoxEnabled}"
+                              Style="{DynamicResource CustomComboBoxStyle}"
+                              Height="22"
+                              Width="250"
+                              HorizontalAlignment="Left"/>
+
+                    <Label x:Name="DumpingProgramLabel"
+                           Grid.Row="3"
                            Grid.Column="0"
                            VerticalAlignment="Center"
                            Content="{DynamicResource DumpingProgramLabelString}"/>
                     <ComboBox x:Name="DumpingProgramComboBox"
-                              Grid.Row="2"
+                              Grid.Row="3"
                               Grid.Column="1"
                               ItemsSource="{Binding AvailableInternalPrograms}"
                               SelectedItem="{Binding Path=CurrentProgram, Converter={StaticResource ElementConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"


### PR DESCRIPTION
Fixes #965 
Drive dropdown defaults to None and if a drive is selected it will use that drive during Check and scan it.
Pic of UI below:
<img width="585" height="328" alt="image" src="https://github.com/user-attachments/assets/4457cb06-5775-438c-b850-c9e5e3cdb412" />
And while scanning:
<img width="453" height="145" alt="image" src="https://github.com/user-attachments/assets/3659f275-3253-4512-94c5-7f67e68a2a1b" />
